### PR TITLE
Fix all build warnings

### DIFF
--- a/App/Dialogs/ConnectDialog.cs
+++ b/App/Dialogs/ConnectDialog.cs
@@ -49,7 +49,7 @@ public class ConnectDialog : Dialog
             IsDefault = true
         };
 
-        connectButton.Accepting += (s, e) =>
+        connectButton.Accepting += (_, _) =>
         {
             if (ValidateEndpoint())
             {
@@ -65,7 +65,7 @@ public class ConnectDialog : Dialog
             Text = "Cancel"
         };
 
-        cancelButton.Accepting += (s, e) =>
+        cancelButton.Accepting += (_, _) =>
         {
             _confirmed = false;
             Application.RequestStop();

--- a/App/Dialogs/SettingsDialog.cs
+++ b/App/Dialogs/SettingsDialog.cs
@@ -50,7 +50,7 @@ public class SettingsDialog : Dialog
             IsDefault = true
         };
 
-        applyButton.Accepting += (s, e) =>
+        applyButton.Accepting += (_, _) =>
         {
             if (ValidateSettings())
             {
@@ -66,7 +66,7 @@ public class SettingsDialog : Dialog
             Text = "Cancel"
         };
 
-        cancelButton.Accepting += (s, e) =>
+        cancelButton.Accepting += (_, _) =>
         {
             _confirmed = false;
             Application.RequestStop();

--- a/App/Dialogs/TrendPlotDialog.cs
+++ b/App/Dialogs/TrendPlotDialog.cs
@@ -89,7 +89,7 @@ public class TrendPlotDialog : Dialog
             Text = $"{Theme.ButtonPrefix}EXIT{Theme.ButtonSuffix}",
             ColorScheme = Theme.ButtonColorScheme
         };
-        _closeButton.Accepting += (s, e) => Application.RequestStop();
+        _closeButton.Accepting += (_, _) => Application.RequestStop();
 
         buttonFrame.Add(_selectNodeButton, _demoButton, _clearButton, _closeButton);
 
@@ -111,7 +111,7 @@ public class TrendPlotDialog : Dialog
         _trendPlotView.SetFocus();
     }
 
-    private void OnSelectNode(object? sender, CommandEventArgs e)
+    private void OnSelectNode(object? _, CommandEventArgs _1)
     {
         if (_availableNodes == null || !_availableNodes.Any())
         {
@@ -174,7 +174,7 @@ public class TrendPlotDialog : Dialog
         };
 
         MonitoredNode? selectedNode = null;
-        selectButton.Accepting += (s, ev) =>
+        selectButton.Accepting += (_, _) =>
         {
             if (listView.SelectedItem >= 0 && listView.SelectedItem < nodeList.Count)
             {
@@ -183,7 +183,7 @@ public class TrendPlotDialog : Dialog
             }
         };
 
-        cancelButton.Accepting += (s, ev) => Application.RequestStop();
+        cancelButton.Accepting += (_, _) => Application.RequestStop();
 
         dialog.Add(headerLabel, listView, hintLabel, selectButton, cancelButton);
         listView.SetFocus();
@@ -208,7 +208,7 @@ public class TrendPlotDialog : Dialog
         }
     }
 
-    private void OnDemoMode(object? sender, CommandEventArgs e)
+    private void OnDemoMode(object? _, CommandEventArgs _1)
     {
         StartDemoMode();
     }
@@ -219,7 +219,7 @@ public class TrendPlotDialog : Dialog
         _trendPlotView.StartDemoMode();
     }
 
-    private void OnClear(object? sender, CommandEventArgs e)
+    private void OnClear(object? _, CommandEventArgs _1)
     {
         _trendPlotView.Clear();
     }

--- a/App/Dialogs/WriteValueDialog.cs
+++ b/App/Dialogs/WriteValueDialog.cs
@@ -66,7 +66,7 @@ public class WriteValueDialog : Dialog
             IsDefault = true
         };
 
-        writeButton.Accepting += (s, e) =>
+        writeButton.Accepting += (_, _) =>
         {
             if (ValidateAndParse())
             {
@@ -91,7 +91,7 @@ public class WriteValueDialog : Dialog
             Text = "Cancel"
         };
 
-        cancelButton.Accepting += (s, e) =>
+        cancelButton.Accepting += (_, _) =>
         {
             _confirmed = false;
             Application.RequestStop();

--- a/App/Views/AddressSpaceView.cs
+++ b/App/Views/AddressSpaceView.cs
@@ -35,7 +35,7 @@ public class AddressSpaceView : FrameView
             )
         };
 
-        _treeView.SelectionChanged += (sender, args) =>
+        _treeView.SelectionChanged += (_, args) =>
         {
             if (args.NewValue != null)
             {
@@ -94,7 +94,7 @@ public class AddressSpaceView : FrameView
         return node.HasChildren;
     }
 
-    private void HandleKeyDown(object? sender, Key e)
+    private void HandleKeyDown(object? _, Key e)
     {
         if (e == Key.Enter || e == Key.Space)
         {
@@ -112,7 +112,7 @@ public class AddressSpaceView : FrameView
         }
     }
 
-    private void HandleObjectActivated(object? sender, ObjectActivatedEventArgs<BrowsedNode> e)
+    private void HandleObjectActivated(object? _, ObjectActivatedEventArgs<BrowsedNode> e)
     {
         if (e.ActivatedObject != null && e.ActivatedObject.NodeClass == Opc.Ua.NodeClass.Variable)
         {

--- a/App/Views/MonitoredItemsView.cs
+++ b/App/Views/MonitoredItemsView.cs
@@ -109,7 +109,7 @@ public class MonitoredItemsView : FrameView
         _tableView.Update();
     }
 
-    private void HandleKeyDown(object? sender, Key e)
+    private void HandleKeyDown(object? _, Key e)
     {
         if (e == Key.Delete || e == Key.Backspace)
         {

--- a/OpcUa/OpcUaClientWrapper.cs
+++ b/OpcUa/OpcUaClientWrapper.cs
@@ -53,7 +53,7 @@ public class OpcUaClientWrapper : IDisposable
 
         // Accept all certificates for simplicity
         var certificateValidator = new CertificateValidator();
-        certificateValidator.CertificateValidation += (sender, e) =>
+        certificateValidator.CertificateValidation += (_, e) =>
         {
             e.Accept = true;
         };


### PR DESCRIPTION
Replace unused sender/event parameters with discard pattern (_) to suppress CS8604 warnings in event handler lambdas and methods.

Files modified:
- App/Dialogs/ConnectDialog.cs
- App/Dialogs/SettingsDialog.cs
- App/Dialogs/TrendPlotDialog.cs
- App/Dialogs/WriteValueDialog.cs
- App/Views/AddressSpaceView.cs
- App/Views/MonitoredItemsView.cs
- OpcUa/OpcUaClientWrapper.cs