### PR TITLE
Add environment setup docs and package download script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,31 @@
 ## Overview
 OpcScope is a terminal-based OPC UA client/monitor application built with .NET 10, Terminal.Gui v2, and OPC Foundation Client SDK (`OPCFoundation.NetStandard.Opc.Ua.Client`).
 
+## Environment Setup
+
+### .NET SDK Installation
+If the `dotnet` command is not available, install .NET 10 SDK using Microsoft's install script:
+
+```bash
+# Download and run the install script
+curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+chmod +x /tmp/dotnet-install.sh
+/tmp/dotnet-install.sh --channel 10.0 --install-dir ~/.dotnet
+
+# Add to PATH for the current session
+export PATH="$HOME/.dotnet:$PATH"
+```
+
+### NuGet Package Restore
+The project uses a local package source to avoid network/proxy issues. If `dotnet restore` fails:
+
+1. Run the package download script: `./scripts/download-packages.sh`
+2. The script uses `curl` to download packages from nuget.org (curl handles proxies better than NuGet)
+3. Packages are stored in `./packages/` directory
+4. NuGet.Config is configured to use only this local source
+
+**Note**: In environments with restrictive proxies, .NET's HttpClient may fail to authenticate with the proxy even when `HTTP_PROXY`/`HTTPS_PROXY` are set. The download script works around this by using `curl` which handles proxy authentication correctly.
+
 ## Build & Run
 
 ```bash
@@ -161,8 +186,10 @@ Available test nodes:
 
 ## Common Issues
 
-1. **NuGet restore fails**: Use local package source or `scripts/download-packages.sh`
-2. **Tests fail with Xunit errors in main project**: Ensure `tests/**` is excluded in OpcScope.csproj
-3. **UI thread exceptions**: Always use `Application.Invoke()` for UI updates from background threads
-4. **Ambiguous NodeBrowser reference**: OPC Foundation has its own `Browser` class - use fully qualified names if needed
-5. **Certificate validation errors**: Set `AutoAcceptUntrustedCertificates = true` in SecurityConfiguration for development
+1. **`dotnet` command not found**: Install .NET SDK using the install script (see Environment Setup above)
+2. **NuGet restore fails with proxy/401 errors**: Run `./scripts/download-packages.sh` to download packages via curl
+3. **Tests fail with Xunit errors in main project**: Ensure `tests/**` is excluded in OpcScope.csproj
+4. **UI thread exceptions**: Always use `Application.Invoke()` for UI updates from background threads
+5. **Ambiguous NodeBrowser reference**: OPC Foundation has its own `Browser` class - use fully qualified names if needed
+6. **Certificate validation errors**: Set `AutoAcceptUntrustedCertificates = true` in SecurityConfiguration for development
+7. **Integration tests fail with "Unexpected error starting application"**: The OPC UA test server requires specific environment permissions - unit tests will still pass

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="local" value="./packages" />
   </packageSources>
 </configuration>

--- a/scripts/download-packages.sh
+++ b/scripts/download-packages.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Script to download NuGet packages for offline use
+# Packages are downloaded from nuget.org using curl
+
+set -e
+
+PACKAGES_DIR="$(dirname "$0")/../packages"
+mkdir -p "$PACKAGES_DIR"
+
+download_package() {
+    local id="${1,,}"  # lowercase
+    local version="$2"
+    local filename="${id}.${version}.nupkg"
+    local url="https://api.nuget.org/v3-flatcontainer/${id}/${version}/${filename}"
+
+    if [ -f "$PACKAGES_DIR/$filename" ]; then
+        echo "Already exists: $filename"
+    else
+        echo "Downloading: $filename"
+        curl -sSL -o "$PACKAGES_DIR/$filename" "$url"
+    fi
+}
+
+# Main project packages
+download_package "Terminal.Gui" "2.0.0"
+download_package "OPCFoundation.NetStandard.Opc.Ua.Client" "1.5.374.126"
+
+# OPC Foundation dependencies
+download_package "OPCFoundation.NetStandard.Opc.Ua.Core" "1.5.374.126"
+download_package "OPCFoundation.NetStandard.Opc.Ua.Configuration" "1.5.374.126"
+download_package "OPCFoundation.NetStandard.Opc.Ua.Security.Certificates" "1.5.374.126"
+download_package "OPCFoundation.NetStandard.Opc.Ua.Bindings.Https" "1.5.374.126"
+
+# Test project packages
+download_package "coverlet.collector" "6.0.2"
+download_package "Microsoft.NET.Test.Sdk" "17.11.0"
+download_package "Moq" "4.20.72"
+download_package "OPCFoundation.NetStandard.Opc.Ua.Server" "1.5.374.126"
+download_package "xunit" "2.9.0"
+download_package "xunit.runner.visualstudio" "2.8.0"
+
+# Common transitive dependencies
+download_package "xunit.abstractions" "2.0.3"
+download_package "xunit.core" "2.9.0"
+download_package "xunit.extensibility.core" "2.9.0"
+download_package "xunit.extensibility.execution" "2.9.0"
+download_package "xunit.assert" "2.9.0"
+download_package "xunit.analyzers" "1.15.0"
+download_package "Castle.Core" "5.1.1"
+download_package "System.IO.Pipelines" "8.0.0"
+download_package "Microsoft.Extensions.Logging.Abstractions" "8.0.2"
+download_package "Microsoft.Extensions.Logging" "8.0.1"
+download_package "Microsoft.Extensions.Logging" "8.0.0"
+download_package "Portable.BouncyCastle" "1.9.0"
+download_package "Newtonsoft.Json" "13.0.3"
+download_package "Microsoft.CodeCoverage" "17.11.0"
+download_package "Microsoft.TestPlatform.TestHost" "17.11.0"
+download_package "Microsoft.TestPlatform.ObjectModel" "17.11.0"
+download_package "NuGet.Frameworks" "6.11.0"
+download_package "System.Reflection.Metadata" "8.0.0"
+download_package "System.Collections.Immutable" "8.0.0"
+
+# Additional transitive dependencies (Terminal.Gui and more)
+download_package "ColorHelper" "1.8.1"
+download_package "JetBrains.Annotations" "2024.2.0"
+download_package "Microsoft.CodeAnalysis" "4.11.0"
+download_package "Microsoft.CodeAnalysis.CSharp" "4.11.0"
+download_package "Microsoft.CodeAnalysis.Common" "4.11.0"
+download_package "Microsoft.CodeAnalysis.CSharp.Workspaces" "4.11.0"
+download_package "Microsoft.CodeAnalysis.VisualBasic.Workspaces" "4.11.0"
+download_package "Microsoft.CodeAnalysis.Workspaces.Common" "4.11.0"
+download_package "Microsoft.CodeAnalysis.VisualBasic" "4.11.0"
+download_package "Microsoft.SourceLink.GitHub" "8.0.0"
+download_package "Microsoft.SourceLink.Common" "8.0.0"
+download_package "System.IO.Abstractions" "21.0.29"
+download_package "System.Text.Json" "8.0.5"
+download_package "Wcwidth" "2.0.0"
+download_package "Microsoft.Extensions.DependencyInjection" "8.0.1"
+download_package "Microsoft.Extensions.DependencyInjection.Abstractions" "8.0.2"
+download_package "Microsoft.Extensions.Options" "8.0.2"
+download_package "Microsoft.Extensions.Primitives" "8.0.0"
+download_package "System.Diagnostics.EventLog" "8.0.0"
+download_package "Microsoft.CodeAnalysis.Analyzers" "3.3.4"
+download_package "Microsoft.Build.Tasks.Git" "8.0.0"
+download_package "System.Text.Encoding.CodePages" "8.0.0"
+download_package "Humanizer.Core" "2.14.1"
+download_package "Microsoft.Bcl.AsyncInterfaces" "8.0.0"
+download_package "System.Composition" "8.0.0"
+download_package "System.Composition.AttributedModel" "8.0.0"
+download_package "System.Composition.Convention" "8.0.0"
+download_package "System.Composition.Hosting" "8.0.0"
+download_package "System.Composition.Runtime" "8.0.0"
+download_package "System.Composition.TypedParts" "8.0.0"
+download_package "TestableIO.System.IO.Abstractions" "21.0.29"
+download_package "TestableIO.System.IO.Abstractions.Wrappers" "21.0.29"
+
+echo "Done downloading packages to $PACKAGES_DIR"


### PR DESCRIPTION
- Add Environment Setup section to CLAUDE.md with .NET SDK install instructions
- Add NuGet package restore documentation for proxy-restricted environments
- Create scripts/download-packages.sh to download NuGet packages via curl
- Configure NuGet.Config to use only local package source
- Update Common Issues section with new troubleshooting items