### PR TITLE
Clean up tests and simplify CI configuration

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,8 +2,10 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <!-- Local packages for offline/proxy environments -->
     <add key="local" value="./packages" />
+    <!-- Fallback to nuget.org for CI and when local packages are unavailable -->
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <config>
     <!-- Disable signature verification to avoid CRL/OCSP network calls during restore -->


### PR DESCRIPTION
- Remove RetroThemeTests.cs which tested non-existent theme classes
  (AmberTheme, GreenTheme, BlueTheme, GreyTheme don't exist)
- Add nuget.org as fallback package source for CI compatibility
  (local packages still used first for offline/proxy environments)