### PR TITLE
Add Square Wave Systems branding to OPC Scope

### DIFF
--- a/App/MainWindow.cs
+++ b/App/MainWindow.cs
@@ -23,12 +23,14 @@ public class MainWindow : Toplevel
     private EmbeddedTestServer? _testServer;
     private bool _isStartingTestServer;
 
+    private readonly Label _titleBanner;
     private readonly MenuBar _menuBar;
     private readonly AddressSpaceView _addressSpaceView;
     private readonly MonitoredItemsView _monitoredItemsView;
     private readonly NodeDetailsView _nodeDetailsView;
     private readonly LogView _logView;
     private readonly StatusBar _statusBar;
+    private readonly Label _companyLabel;
     private readonly SpinnerView _activitySpinner;
     private readonly Label _activityLabel;
 
@@ -48,6 +50,15 @@ public class MainWindow : Toplevel
         // Subscribe to theme changes
         ThemeManager.ThemeChanged += OnThemeChanged;
 
+        // Create title banner
+        _titleBanner = new Label
+        {
+            X = Pos.Center(),
+            Y = 0,
+            Text = "═══╡ OPC Scope ╞═══",
+            ColorScheme = new ColorScheme { Normal = new Terminal.Gui.Attribute(Color.BrightCyan, Color.Black) }
+        };
+
         // Create menu bar
         _menuBar = CreateMenuBar();
 
@@ -55,7 +66,7 @@ public class MainWindow : Toplevel
         _addressSpaceView = new AddressSpaceView
         {
             X = 0,
-            Y = 1,
+            Y = 2,
             Width = Dim.Percent(35),
             Height = Dim.Percent(60)
         };
@@ -63,7 +74,7 @@ public class MainWindow : Toplevel
         _monitoredItemsView = new MonitoredItemsView
         {
             X = Pos.Right(_addressSpaceView),
-            Y = 1,
+            Y = 2,
             Width = Dim.Fill(),
             Height = Dim.Percent(60)
         };
@@ -94,6 +105,16 @@ public class MainWindow : Toplevel
         _statusBar.Add(new Shortcut(Key.Enter, "Subscribe", SubscribeSelected));
         _statusBar.Add(new Shortcut(Key.Delete, "Unsubscribe", UnsubscribeSelected));
         _statusBar.Add(new Shortcut(Key.F10, "Menu", () => _menuBar.OpenMenu()));
+
+        // Company branding label (bottom right)
+        _companyLabel = new Label
+        {
+            X = Pos.AnchorEnd(25),
+            Y = 0,
+            Text = "Square Wave Systems 2026",
+            ColorScheme = new ColorScheme { Normal = new Terminal.Gui.Attribute(Color.DarkGray, Color.Black) }
+        };
+        _statusBar.Add(_companyLabel);
 
         // Create activity spinner for async operations
         _activitySpinner = new SpinnerView
@@ -126,6 +147,7 @@ public class MainWindow : Toplevel
         _nodeDetailsView.Initialize(_nodeBrowser);
 
         // Add all views
+        Add(_titleBanner);
         Add(_menuBar);
         Add(_addressSpaceView);
         Add(_monitoredItemsView);
@@ -137,7 +159,7 @@ public class MainWindow : Toplevel
         ApplyTheme();
 
         // Log startup
-        _logger.Info("OpcScope started");
+        _logger.Info("OPC Scope started - Square Wave Systems");
         _logger.Info("Press F10 for menu, or use Connection -> Connect");
     }
 
@@ -153,6 +175,7 @@ public class MainWindow : Toplevel
 
         return new MenuBar
         {
+            Y = 1,
             Menus = new MenuBarItem[]
             {
                 new MenuBarItem("_File", new MenuItem[]
@@ -193,6 +216,18 @@ public class MainWindow : Toplevel
         // Apply main window styling
         ColorScheme = theme.MainColorScheme;
         BorderStyle = theme.BorderLineStyle;
+
+        // Apply styling to title banner (use accent color for branding)
+        _titleBanner.ColorScheme = new ColorScheme
+        {
+            Normal = theme.AccentBrightAttr
+        };
+
+        // Apply styling to company label (subtle in status bar)
+        _companyLabel.ColorScheme = new ColorScheme
+        {
+            Normal = new Terminal.Gui.Attribute(theme.ForegroundDim, theme.Background)
+        };
 
         // Apply styling to menu and status bar
         ThemeStyler.ApplyToMenuBar(_menuBar, theme);
@@ -477,7 +512,7 @@ public class MainWindow : Toplevel
 
     private void UpdateConnectionStatus(string status)
     {
-        Title = $"OpcScope - {status}";
+        Title = $"OPC Scope - {status}";
         SetNeedsLayout();
     }
 
@@ -638,7 +673,8 @@ public class MainWindow : Toplevel
 
     private void ShowHelp()
     {
-        var help = @"OpcScope - Terminal OPC UA Client
+        var help = @"OPC Scope - Terminal OPC UA Client
+by Square Wave Systems
 
 Keyboard Shortcuts:
   F1        - Show this help
@@ -666,13 +702,16 @@ Tips:
   - Values update in real-time via subscription
   - Use View > Trend Plot to visualize values
 ";
-        MessageBox.Query("Help", help, "OK");
+        MessageBox.Query("OPC Scope Help", help, "OK");
     }
 
     private void ShowAbout()
     {
         var theme = ThemeManager.Current;
-        var about = $@"OpcScope v1.0.0
+        var about = $@"╔══════════════════════════════════════╗
+║           OPC Scope v1.0.0           ║
+║      by Square Wave Systems          ║
+╚══════════════════════════════════════╝
 
 A lightweight terminal-based OPC UA client
 for browsing, monitoring, and subscribing
@@ -689,11 +728,11 @@ Built with:
 Themes inspired by:
   - Cassette Futurism (Alien, Blade Runner)
   - github.com/Imetomi/retro-futuristic-ui-design
-  - squarewavesystems.github.io
 
+© 2026 Square Wave Systems
 License: MIT
 ";
-        MessageBox.Query("About OpcScope", about, "OK");
+        MessageBox.Query("About OPC Scope", about, "OK");
     }
 
     protected override void Dispose(bool disposing)


### PR DESCRIPTION
- Add centered "OPC Scope" title banner at top of window
- Add "Square Wave Systems 2026" label in status bar (bottom right)
- Update About dialog with company branding and ASCII box decoration
- Update Help dialog with company attribution
- Rename "OpcScope" to "OPC Scope" throughout the UI
- Branding colors adapt to selected theme