### PR TITLE
Refactor OpcScope terminology to OPC UA standard

### DIFF
--- a/App/Dialogs/TrendPlotDialog.cs
+++ b/App/Dialogs/TrendPlotDialog.cs
@@ -26,7 +26,7 @@ public class TrendPlotDialog : Dialog
     public TrendPlotDialog(SubscriptionManager? subscriptionManager = null, MonitoredNode? initialNode = null)
     {
         _subscriptionManager = subscriptionManager;
-        _availableNodes = subscriptionManager?.MonitoredItems;
+        _availableNodes = subscriptionManager?.MonitoredVariables;
 
         Title = $"{Theme.TitleDecoration}[ OSCILLOSCOPE ]{Theme.TitleDecoration}";
         Width = Dim.Percent(85);
@@ -119,7 +119,7 @@ public class TrendPlotDialog : Dialog
     {
         if (_availableNodes == null || !_availableNodes.Any())
         {
-            MessageBox.Query(Theme.NoSignalMessage, "No monitored items available.\nSubscribe to a variable node first.", "OK");
+            MessageBox.Query(Theme.NoSignalMessage, "No monitored variables available.\nSubscribe to a variable node first.", "OK");
             return;
         }
 

--- a/App/Themes/AppTheme.cs
+++ b/App/Themes/AppTheme.cs
@@ -48,7 +48,7 @@ public abstract class AppTheme
     public virtual LineStyle FrameLineStyle => LineStyle.Double;
 
     /// <summary>
-    /// LineStyle for emphasized panels (main window, monitored items) - typically double-line
+    /// LineStyle for emphasized panels (main window, monitored variables) - typically double-line
     /// </summary>
     public virtual LineStyle EmphasizedBorderStyle => LineStyle.Double;
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ OpcScope/
 │   ├── MainWindow.cs               # Main UI layout, menu bar, status bar, event orchestration
 │   ├── Views/
 │   │   ├── AddressSpaceView.cs     # TreeView for OPC UA address space navigation
-│   │   ├── MonitoredItemsView.cs   # TableView for subscribed items with selection
+│   │   ├── MonitoredVariablesView.cs # TableView for subscribed variables with selection
 │   │   ├── NodeDetailsView.cs      # Node attribute display panel
 │   │   ├── LogView.cs              # Application log display
 │   │   ├── ScopeView.cs            # Real-time multi-signal oscilloscope view
@@ -113,10 +113,10 @@ OpcScope/
 │   ├── OpcUaClientWrapper.cs       # OPC Foundation Session wrapper with connection management
 │   ├── ConnectionManager.cs        # Connection lifecycle orchestration (connect/disconnect/reconnect)
 │   ├── NodeBrowser.cs              # Address space navigation and browsing
-│   ├── SubscriptionManager.cs      # OPC UA Subscription with MonitoredItems
+│   ├── SubscriptionManager.cs      # OPC UA Subscription with MonitoredVariables
 │   └── Models/
 │       ├── BrowsedNode.cs          # Address space node model for tree view
-│       └── MonitoredNode.cs        # Monitored item model with value tracking
+│       └── MonitoredNode.cs        # Monitored variable model with value tracking
 │
 ├── Utilities/
 │   ├── Logger.cs                   # In-app logging service
@@ -216,7 +216,7 @@ Real-time visualization of up to 5 signals simultaneously:
 - Distinct colors per signal (Green, Cyan, Yellow, Magenta, White)
 
 ### CSV Recording
-Record monitored item values to CSV files:
+Record monitored variable values to CSV files:
 - Background queue-based writing (non-blocking)
 - ISO 8601 timestamps with millisecond precision
 - CSV format: `Timestamp,DisplayName,NodeId,Value,Status`
@@ -309,8 +309,8 @@ var connectionManager = new ConnectionManager(logger);
 // Events
 connectionManager.StateChanged += state => { /* Connecting, Connected, Disconnected, Reconnecting */ };
 connectionManager.ValueChanged += node => { /* Handle value updates */ };
-connectionManager.ItemAdded += node => { /* Handle new subscription */ };
-connectionManager.ItemRemoved += handle => { /* Handle unsubscription */ };
+connectionManager.VariableAdded += node => { /* Handle new subscription */ };
+connectionManager.VariableRemoved += handle => { /* Handle unsubscription */ };
 
 // Operations
 await connectionManager.ConnectAsync("opc.tcp://localhost:4840");
@@ -394,7 +394,7 @@ OPC Foundation callbacks arrive on background threads. All UI updates are marsha
 
 ```csharp
 // Using UiThread helper
-UiThread.Run(() => _monitoredItemsView.UpdateItem(item));
+UiThread.Run(() => _monitoredVariablesView.UpdateVariable(variable));
 
 // Using Application.Invoke directly
 Application.Invoke(() => SetNeedsLayout());
@@ -448,10 +448,10 @@ Automates release builds and publishing.
 | F5 | Refresh address space tree |
 | F10 | Open menu |
 | Enter | Subscribe to selected node |
-| Delete | Unsubscribe from selected item |
-| Space | Toggle recording selection (in monitored items) |
-| W | Write value to selected item |
-| Ctrl+G | Open Scope with selected items |
+| Delete | Unsubscribe from selected variable |
+| Space | Toggle recording selection (in monitored variables) |
+| W | Write value to selected variable |
+| Ctrl+G | Open Scope with selected variables |
 | Ctrl+R | Toggle recording (start/stop) |
 | Ctrl+N | New configuration |
 | Ctrl+O | Open configuration |

--- a/Configuration/ConfigurationService.cs
+++ b/Configuration/ConfigurationService.cs
@@ -132,13 +132,13 @@ public class ConfigurationService
     /// </summary>
     /// <param name="endpointUrl">The current server endpoint URL.</param>
     /// <param name="publishingInterval">The current publishing interval in ms.</param>
-    /// <param name="monitoredItems">The current monitored items.</param>
+    /// <param name="monitoredVariables">The current monitored variables.</param>
     /// <param name="existingMetadata">Optional existing metadata to preserve.</param>
     /// <returns>A new configuration object representing the current state.</returns>
     public OpcScopeConfig CaptureCurrentState(
         string? endpointUrl,
         int publishingInterval,
-        IEnumerable<MonitoredNode> monitoredItems,
+        IEnumerable<MonitoredNode> monitoredVariables,
         ConfigMetadata? existingMetadata = null)
     {
         return new OpcScopeConfig
@@ -151,7 +151,7 @@ public class ConfigurationService
             {
                 PublishingIntervalMs = publishingInterval
             },
-            MonitoredNodes = monitoredItems.Select(m => new MonitoredNodeConfig
+            MonitoredNodes = monitoredVariables.Select(m => new MonitoredNodeConfig
             {
                 NodeId = m.NodeId.ToString(),
                 DisplayName = m.DisplayName,

--- a/Configuration/Models/OpcScopeConfig.cs
+++ b/Configuration/Models/OpcScopeConfig.cs
@@ -85,7 +85,7 @@ public class SubscriptionSettings
     public int PublishingIntervalMs { get; set; } = 1000;
 
     /// <summary>
-    /// Default sampling interval (in milliseconds) for monitored items.
+    /// Default sampling interval (in milliseconds) for monitored variables.
     /// <para>
     /// Note: As of version 1.0, this setting is defined in the configuration model but is not yet
     /// applied by the configuration loading logic. It is reserved for future use.
@@ -94,7 +94,7 @@ public class SubscriptionSettings
     public int SamplingIntervalMs { get; set; } = 500;
 
     /// <summary>
-    /// Default queue size for monitored items.
+    /// Default queue size for monitored variables.
     /// <para>
     /// Note: As of version 1.0, this setting is defined in the configuration model but is not yet
     /// applied by the configuration loading logic. It is reserved for future use.

--- a/OpcUa/ConnectionManager.cs
+++ b/OpcUa/ConnectionManager.cs
@@ -41,7 +41,7 @@ public sealed class ConnectionManager : IDisposable
     public NodeBrowser NodeBrowser => _nodeBrowser;
 
     /// <summary>
-    /// Gets the subscription manager for monitored items.
+    /// Gets the subscription manager for monitored variables.
     /// </summary>
     public SubscriptionManager? SubscriptionManager => _subscriptionManager;
 
@@ -56,19 +56,19 @@ public sealed class ConnectionManager : IDisposable
     public event Action<string>? ConnectionError;
 
     /// <summary>
-    /// Raised when a value changes on a monitored item.
+    /// Raised when a value changes on a monitored variable.
     /// </summary>
     public event Action<Models.MonitoredNode>? ValueChanged;
 
     /// <summary>
-    /// Raised when a monitored item is added.
+    /// Raised when a monitored variable is added.
     /// </summary>
-    public event Action<Models.MonitoredNode>? ItemAdded;
+    public event Action<Models.MonitoredNode>? VariableAdded;
 
     /// <summary>
-    /// Raised when a monitored item is removed.
+    /// Raised when a monitored variable is removed.
     /// </summary>
-    public event Action<uint>? ItemRemoved;
+    public event Action<uint>? VariableRemoved;
 
     public ConnectionManager(Logger logger)
     {
@@ -180,7 +180,7 @@ public sealed class ConnectionManager : IDisposable
     }
 
     /// <summary>
-    /// Unsubscribes from a monitored item.
+    /// Unsubscribes from a monitored variable.
     /// </summary>
     public Task<bool> UnsubscribeAsync(uint clientHandle)
     {
@@ -193,8 +193,8 @@ public sealed class ConnectionManager : IDisposable
         await _subscriptionManager.InitializeAsync();
 
         _subscriptionManager.ValueChanged += node => ValueChanged?.Invoke(node);
-        _subscriptionManager.ItemAdded += node => ItemAdded?.Invoke(node);
-        _subscriptionManager.ItemRemoved += handle => ItemRemoved?.Invoke(handle);
+        _subscriptionManager.VariableAdded += node => VariableAdded?.Invoke(node);
+        _subscriptionManager.VariableRemoved += handle => VariableRemoved?.Invoke(handle);
     }
 
     private void DisposeSubscription()
@@ -202,8 +202,8 @@ public sealed class ConnectionManager : IDisposable
         if (_subscriptionManager != null)
         {
             _subscriptionManager.ValueChanged -= node => ValueChanged?.Invoke(node);
-            _subscriptionManager.ItemAdded -= node => ItemAdded?.Invoke(node);
-            _subscriptionManager.ItemRemoved -= handle => ItemRemoved?.Invoke(handle);
+            _subscriptionManager.VariableAdded -= node => VariableAdded?.Invoke(node);
+            _subscriptionManager.VariableRemoved -= handle => VariableRemoved?.Invoke(handle);
             _subscriptionManager.Dispose();
             _subscriptionManager = null;
         }

--- a/OpcUa/Models/MonitoredNode.cs
+++ b/OpcUa/Models/MonitoredNode.cs
@@ -3,7 +3,7 @@ using Opc.Ua;
 namespace OpcScope.OpcUa.Models;
 
 /// <summary>
-/// View model for monitored items displayed in the table.
+/// View model for monitored variables displayed in the table.
 /// </summary>
 public class MonitoredNode
 {

--- a/Utilities/CsvRecordingManager.cs
+++ b/Utilities/CsvRecordingManager.cs
@@ -4,7 +4,7 @@ using OpcScope.OpcUa.Models;
 namespace OpcScope.Utilities;
 
 /// <summary>
-/// Manages CSV recording of monitored item value changes.
+/// Manages CSV recording of monitored variable value changes.
 /// Writes data to file in real-time as values change using a background queue.
 /// </summary>
 public class CsvRecordingManager : IDisposable


### PR DESCRIPTION
This change updates the codebase to use OPC UA specification terminology where "Item" is replaced with "Variable" throughout the application.

Changes include:
- Rename MonitoredItemsView.cs to MonitoredVariablesView.cs
- Rename class MonitoredItemsView to MonitoredVariablesView
- Rename events ItemAdded/ItemRemoved to VariableAdded/VariableRemoved
- Rename property MonitoredItems to MonitoredVariables
- Rename methods AddItem/UpdateItem/RemoveItem to Add/Update/RemoveVariable
- Update field names _monitoredItems to _monitoredVariables
- Update UI strings and help text to use "variable" terminology
- Update CLAUDE.md documentation
- Update XML doc comments

Note: OPC UA SDK types (MonitoredItem, _opcMonitoredItems) are preserved as they reference the actual SDK class names from OPC Foundation libraries.