### PR TITLE
Fix JSON serialization error in OpcScope

### DIFF
--- a/Configuration/ConfigurationService.cs
+++ b/Configuration/ConfigurationService.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using OpcScope.Configuration.Models;
 using OpcScope.OpcUa.Models;
 
@@ -10,12 +9,6 @@ namespace OpcScope.Configuration;
 /// </summary>
 public class ConfigurationService
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        WriteIndented = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-    };
 
     /// <summary>
     /// Path to the currently loaded configuration file, or null if no file is loaded.
@@ -65,7 +58,7 @@ public class ConfigurationService
     public async Task<OpcScopeConfig> LoadAsync(string filePath)
     {
         var json = await File.ReadAllTextAsync(filePath);
-        var config = JsonSerializer.Deserialize<OpcScopeConfig>(json, JsonOptions)
+        var config = JsonSerializer.Deserialize(json, OpcScopeJsonContext.Default.OpcScopeConfig)
             ?? throw new InvalidDataException("Invalid configuration file");
 
         // Handle version migrations if needed
@@ -119,7 +112,7 @@ public class ConfigurationService
     {
         config.Metadata.LastModified = DateTime.UtcNow;
 
-        var json = JsonSerializer.Serialize(config, JsonOptions);
+        var json = JsonSerializer.Serialize(config, OpcScopeJsonContext.Default.OpcScopeConfig);
         await File.WriteAllTextAsync(filePath, json);
 
         CurrentFilePath = filePath;

--- a/Configuration/OpcScopeJsonContext.cs
+++ b/Configuration/OpcScopeJsonContext.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+using OpcScope.Configuration.Models;
+
+namespace OpcScope.Configuration;
+
+/// <summary>
+/// Source-generated JSON serialization context for OpcScope configuration types.
+/// This enables AOT/trimming-compatible JSON serialization without reflection.
+/// </summary>
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(OpcScopeConfig))]
+[JsonSerializable(typeof(List<string>))]
+internal partial class OpcScopeJsonContext : JsonSerializerContext
+{
+}

--- a/Configuration/RecentFilesManager.cs
+++ b/Configuration/RecentFilesManager.cs
@@ -113,7 +113,7 @@ public class RecentFilesManager
             if (File.Exists(_settingsPath))
             {
                 var json = File.ReadAllText(_settingsPath);
-                _recentFiles = JsonSerializer.Deserialize<List<string>>(json) ?? new();
+                _recentFiles = JsonSerializer.Deserialize(json, OpcScopeJsonContext.Default.ListString) ?? new();
             }
         }
         catch
@@ -132,7 +132,7 @@ public class RecentFilesManager
             {
                 Directory.CreateDirectory(directory);
             }
-            File.WriteAllText(_settingsPath, JsonSerializer.Serialize(_recentFiles));
+            File.WriteAllText(_settingsPath, JsonSerializer.Serialize(_recentFiles, OpcScopeJsonContext.Default.ListString));
         }
         catch
         {


### PR DESCRIPTION
Replace reflection-based JSON serialization with source-generated JsonSerializerContext to fix errors in AOT/trimmed builds. This change:

- Add OpcScopeJsonContext with [JsonSerializable] for OpcScopeConfig and List<string>
- Update ConfigurationService to use source-generated context
- Update RecentFilesManager to use source-generated context
- Remove unused JsonSerializerOptions static field