### PR TITLE
Remove theme section from about dialog

### DIFF
--- a/App/MainWindow.cs
+++ b/App/MainWindow.cs
@@ -905,8 +905,7 @@ public class MainWindow : Toplevel
 
     private void ShowAbout()
     {
-        var theme = ThemeManager.Current;
-        var about = $@"╔══════════════════════════════════════╗
+        var about = @"╔══════════════════════════════════════╗
 ║           OPC Scope v1.0.0           ║
 ║      by Square Wave Systems          ║
 ╚══════════════════════════════════════╝
@@ -919,9 +918,6 @@ Features:
   - Multi-signal Scope view (up to 5 signals)
   - Time-based plotting with auto-scale
   - CSV recording of monitored values
-
-Current Theme: {theme.Name}
-  {theme.Description}
 
 Built with:
   - .NET 10


### PR DESCRIPTION
The current theme info is already accessible via the View menu, so displaying it in the About dialog was redundant.