### PR TITLE
Fix light mode selection contrast visibility

### DIFF
--- a/App/Themes/LightTheme.cs
+++ b/App/Themes/LightTheme.cs
@@ -80,12 +80,15 @@ public class LightTheme : AppTheme
     private ColorScheme? _mainColorScheme;
     private ColorScheme? _menuColorScheme;
 
+    // Highlight color for selection - warm tan for visible contrast on light background
+    private Color HighlightBackground => new(232, 212, 184);  // #e8d4b8 warm tan
+
     public override ColorScheme MainColorScheme => _mainColorScheme ??= new()
     {
         Normal = NormalAttr,
-        Focus = new Attribute(Background, new Color(234, 234, 229)),  // #eaeae5 panel background for focus
+        Focus = new Attribute(Foreground, HighlightBackground),  // Dark text on tan background
         HotNormal = AccentAttr,
-        HotFocus = new Attribute(Background, Accent),
+        HotFocus = new Attribute(Accent, HighlightBackground),   // Amber hotkey on tan background
         Disabled = new Attribute(StatusInactive, Background)
     };
 


### PR DESCRIPTION
Change the light theme Focus attribute to use a visible warm tan background (#e8d4b8) instead of a nearly-invisible pale color.

Before: Selection used light text (#f5f5f0) on pale background (#eaeae5)
After: Selection uses dark text (#1a1a1a) on tan background (#e8d4b8)

This makes selected items in tree views, tables, and other UI elements clearly distinguishable in light mode.