### PR TITLE
Clear text box in connect dialog

### DIFF
--- a/App/Dialogs/ConnectDialog.cs
+++ b/App/Dialogs/ConnectDialog.cs
@@ -17,7 +17,7 @@ public class ConnectDialog : Dialog
     public string EndpointUrl => _endpointField.Text ?? string.Empty;
     public bool Confirmed => _confirmed;
 
-    public ConnectDialog(string? lastEndpoint = null)
+    public ConnectDialog()
     {
         var theme = AppThemeManager.Current;
 
@@ -40,14 +40,12 @@ public class ConnectDialog : Dialog
             Text = "Endpoint URL:"
         };
 
-        string defaultText = lastEndpoint ?? "opc.tcp://localhost:4840";
-
         _endpointField = new TextField
         {
             X = 1,
             Y = 2,
             Width = Dim.Fill(1),
-            Text = defaultText
+            Text = string.Empty
         };
 
         var hintLabel = new Label

--- a/App/MainWindow.cs
+++ b/App/MainWindow.cs
@@ -416,7 +416,7 @@ public class MainWindow : Toplevel
 
     private void ShowConnectDialog()
     {
-        var dialog = new ConnectDialog(_connectionManager.LastEndpoint);
+        var dialog = new ConnectDialog();
         Application.Run(dialog);
 
         if (dialog.Confirmed)


### PR DESCRIPTION
Remove default endpoint text so users can paste directly into the empty text field without having to clear existing content first.