### PR TITLE
Fix scope shortcut and remove trend shortcut

### DIFF
--- a/App/Dialogs/HelpDialog.cs
+++ b/App/Dialogs/HelpDialog.cs
@@ -55,7 +55,6 @@ MONITORED VARIABLES
   Delete           Unsubscribe from item
   Space            Toggle selection (for Scope/Recording)
   W                Write value to node
-  T                Show trend plot
   S                Open Scope with selected
 
 SCOPE VIEW CONTROLS

--- a/App/MainWindow.cs
+++ b/App/MainWindow.cs
@@ -191,7 +191,6 @@ public class MainWindow : Toplevel
         _addressSpaceView.NodeSubscribeRequested += OnSubscribeRequested;
         _monitoredVariablesView.UnsubscribeRequested += OnUnsubscribeRequested;
         _monitoredVariablesView.WriteRequested += OnWriteRequested;
-        _monitoredVariablesView.TrendPlotRequested += OnTrendPlotRequested;
         _monitoredVariablesView.ScopeRequested += LaunchScope;
         _monitoredVariablesView.RecordToggleRequested += ToggleRecording;
 
@@ -617,7 +616,6 @@ public class MainWindow : Toplevel
             _statusBar.Add(new Shortcut(Key.Delete, "Unsub", UnsubscribeSelected));
             _statusBar.Add(new Shortcut(Key.Space, "Sel", () => { })); // Handled by view
             _statusBar.Add(new Shortcut(Key.W, "Write", WriteSelected));
-            _statusBar.Add(new Shortcut(Key.T, "Trend", ShowTrendForSelected));
             _statusBar.Add(new Shortcut(Key.S, "Scope", LaunchScope));
         }
         else
@@ -627,18 +625,6 @@ public class MainWindow : Toplevel
         }
 
         _statusBar.SetNeedsLayout();
-    }
-
-    /// <summary>
-    /// Shows trend plot for the selected variable in the monitored view.
-    /// </summary>
-    private void ShowTrendForSelected()
-    {
-        var variable = _monitoredVariablesView.SelectedVariable;
-        if (variable != null)
-        {
-            OnTrendPlotRequested(variable);
-        }
     }
 
     #endregion
@@ -682,12 +668,6 @@ public class MainWindow : Toplevel
     private void OnUnsubscribeRequested(MonitoredNode item)
     {
         _connectionManager.UnsubscribeAsync(item.ClientHandle).FireAndForget(_logger);
-    }
-
-    private void OnTrendPlotRequested(MonitoredNode item)
-    {
-        var dialog = new TrendPlotDialog(_connectionManager.SubscriptionManager!, item);
-        Application.Run(dialog);
     }
 
     private void OnWriteRequested(MonitoredNode item)

--- a/App/Views/MonitoredVariablesView.cs
+++ b/App/Views/MonitoredVariablesView.cs
@@ -52,7 +52,6 @@ public class MonitoredVariablesView : FrameView
     public event Action<MonitoredNode>? UnsubscribeRequested;
     public event Action? RecordToggleRequested;
     public event Action<MonitoredNode>? WriteRequested;
-    public event Action<MonitoredNode>? TrendPlotRequested;
     public event Action? ScopeRequested;
     public event Action<int>? ScopeSelectionChanged;  // Fires with current selection count
 
@@ -469,15 +468,6 @@ public class MonitoredVariablesView : FrameView
             if (selected != null)
             {
                 WriteRequested?.Invoke(selected);
-                e.Handled = true;
-            }
-        }
-        else if (keyCode == (KeyCode)'t' || keyCode == (KeyCode)'T')
-        {
-            var selected = SelectedVariable;
-            if (selected != null)
-            {
-                TrendPlotRequested?.Invoke(selected);
                 e.Handled = true;
             }
         }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -426,7 +426,7 @@ Automates release builds and publishing.
 | Delete | Unsubscribe from selected variable |
 | Space | Toggle recording selection (in monitored variables) |
 | W | Write value to selected variable |
-| Ctrl+G | Open Scope with selected variables |
+| S | Open Scope with selected variables |
 | Ctrl+R | Toggle recording (start/stop) |
 | Ctrl+N | New configuration |
 | Ctrl+O | Open configuration |


### PR DESCRIPTION
- Remove 't'/'T' key handler for TrendPlot from MonitoredVariablesView
- Remove TrendPlotRequested event and related handlers from MainWindow
- Remove 'T' shortcut from StatusBar
- Update help dialog and CLAUDE.md to reflect current shortcuts
- Fix documentation: Scope shortcut is 'S' not 'Ctrl+G'