### PR TITLE
Add lazygit-inspired keybinding system

### DIFF
--- a/App/Dialogs/QuickHelpDialog.cs
+++ b/App/Dialogs/QuickHelpDialog.cs
@@ -23,12 +23,24 @@ public class QuickHelpDialog : Dialog
 
         // Calculate size based on content
         var bindings = keybindingManager.GetActiveBindings().ToList();
-        var maxKeyWidth = bindings.Max(b => b.KeyDisplay.Length);
-        var maxDescWidth = bindings.Max(b => b.Description.Length);
-        var contentWidth = Math.Max(maxKeyWidth + maxDescWidth + 6, 40);
 
-        Width = Math.Min(contentWidth + 4, 60);
-        Height = Math.Min(bindings.Count + 6, 24);
+        int maxKeyWidth;
+        // Handle empty bindings case
+        if (bindings.Count == 0)
+        {
+            maxKeyWidth = 8; // Default width for "No keybindings"
+            Width = 44;
+            Height = 8;
+        }
+        else
+        {
+            maxKeyWidth = bindings.Max(b => b.KeyDisplay.Length);
+            var maxDescWidth = bindings.Max(b => b.Description.Length);
+            var contentWidth = Math.Max(maxKeyWidth + maxDescWidth + 6, 40);
+
+            Width = Math.Min(contentWidth + 4, 60);
+            Height = Math.Min(bindings.Count + 6, 24);
+        }
 
         var theme = ThemeManager.Current;
 
@@ -82,19 +94,26 @@ public class QuickHelpDialog : Dialog
         Add(closeButton);
     }
 
-    private string GenerateHelpContent(List<Keybinding> bindings, int keyWidth)
+    private static string GenerateHelpContent(List<Keybinding> bindings, int keyWidth)
     {
         var lines = new List<string>();
 
-        // Group by category
-        var groups = bindings.GroupBy(b => b.Category);
-
-        foreach (var group in groups)
+        if (bindings.Count == 0)
         {
-            foreach (var binding in group)
+            lines.Add("  No keybindings available for this context.");
+        }
+        else
+        {
+            // Group by category
+            var groups = bindings.GroupBy(b => b.Category);
+
+            foreach (var group in groups)
             {
-                var key = binding.KeyDisplay.PadRight(keyWidth + 2);
-                lines.Add($"  {key}{binding.Description}");
+                foreach (var binding in group)
+                {
+                    var key = binding.KeyDisplay.PadRight(keyWidth + 2);
+                    lines.Add($"  {key}{binding.Description}");
+                }
             }
         }
 

--- a/App/Keybindings/DefaultKeybindings.cs
+++ b/App/Keybindings/DefaultKeybindings.cs
@@ -245,14 +245,20 @@ public static class DefaultKeybindings
 
     private static void ConfigureScopeBindings(KeybindingManager manager)
     {
-        // Scope view has its own keybindings defined in ScopeView
-        // These are documented for help generation
+        // NOTE: Scope keybindings are handled directly by ScopeView's KeyDown handler
+        // because ScopeView is a modal dialog that captures its own key events.
+        // These registrations exist solely for:
+        //   1. Help text generation (F1 and ? dialogs)
+        //   2. Status bar display when Scope context is active
+        // The empty handlers () => { } are intentional - they are never invoked.
+        // If you need to change Scope keybindings, update both here AND in ScopeView.
+
         manager.Register(
             KeybindingContext.Scope,
             Key.Space,
             "Pause",
             "Pause/resume plotting",
-            () => { }, // Handled by ScopeView directly
+            () => { }, // Documentation only - handled by ScopeView
             showInStatusBar: true,
             statusBarPriority: 10,
             category: "Scope View");
@@ -262,7 +268,7 @@ public static class DefaultKeybindings
             (Key)'+',
             "Zoom+",
             "Zoom in (increase scale)",
-            () => { },
+            () => { }, // Documentation only - handled by ScopeView
             showInStatusBar: true,
             statusBarPriority: 20,
             category: "Scope View");
@@ -272,7 +278,7 @@ public static class DefaultKeybindings
             (Key)'-',
             "Zoom-",
             "Zoom out (decrease scale)",
-            () => { },
+            () => { }, // Documentation only - handled by ScopeView
             showInStatusBar: true,
             statusBarPriority: 21,
             category: "Scope View");
@@ -282,7 +288,7 @@ public static class DefaultKeybindings
             (Key)'r',
             "Reset",
             "Reset to auto-scale",
-            () => { },
+            () => { }, // Documentation only - handled by ScopeView
             showInStatusBar: true,
             statusBarPriority: 30,
             category: "Scope View");

--- a/App/MainWindow.cs
+++ b/App/MainWindow.cs
@@ -658,20 +658,13 @@ public class MainWindow : Toplevel, DefaultKeybindings.IKeybindingActions
 
     /// <summary>
     /// Handles global keyboard shortcuts using lazygit-inspired keybinding manager.
+    /// All keybindings are centralized in <see cref="Keybindings.DefaultKeybindings"/>.
     /// </summary>
     protected override bool OnKeyDown(Key key)
     {
-        // ? key for quick help (check before keybinding manager)
-        if (key.KeyCode == (KeyCode)'?')
+        // Use the centralized keybinding manager for all key handling
+        if (_keybindingManager.TryHandle(key))
         {
-            ShowQuickHelp();
-            return true;
-        }
-
-        // Tab: Cycle between panes
-        if (key == Key.Tab)
-        {
-            _focusManager?.FocusNext();
             return true;
         }
 

--- a/tests/Opcilloscope.Tests/App/Keybindings/KeybindingManagerTests.cs
+++ b/tests/Opcilloscope.Tests/App/Keybindings/KeybindingManagerTests.cs
@@ -1,0 +1,550 @@
+using Opcilloscope.App.Keybindings;
+using Terminal.Gui;
+
+namespace Opcilloscope.Tests.App.Keybindings;
+
+public class KeybindingManagerTests
+{
+    #region Constructor Tests
+
+    [Fact]
+    public void Constructor_InitializesAllContexts()
+    {
+        // Act
+        var manager = new KeybindingManager();
+
+        // Assert - all contexts should be initialized with empty lists
+        foreach (KeybindingContext context in Enum.GetValues<KeybindingContext>())
+        {
+            var bindings = manager.GetBindingsForContext(context);
+            Assert.NotNull(bindings);
+            Assert.Empty(bindings);
+        }
+    }
+
+    [Fact]
+    public void Constructor_DefaultContextIsGlobal()
+    {
+        // Act
+        var manager = new KeybindingManager();
+
+        // Assert
+        Assert.Equal(KeybindingContext.Global, manager.CurrentContext);
+    }
+
+    #endregion
+
+    #region Registration Tests
+
+    [Fact]
+    public void Register_AddsKeybindingToCorrectContext()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        var executed = false;
+
+        // Act
+        manager.Register(
+            KeybindingContext.AddressSpace,
+            Key.Enter,
+            "Subscribe",
+            "Subscribe to node",
+            () => executed = true);
+
+        // Assert
+        var bindings = manager.GetBindingsForContext(KeybindingContext.AddressSpace);
+        Assert.Single(bindings);
+        Assert.Equal(Key.Enter, bindings[0].Key);
+        Assert.Equal("Subscribe", bindings[0].Label);
+    }
+
+    [Fact]
+    public void RegisterGlobal_AddsKeybindingToGlobalContext()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+
+        // Act
+        manager.RegisterGlobal(
+            Key.F1,
+            "Help",
+            "Show help",
+            () => { });
+
+        // Assert
+        var bindings = manager.GetBindingsForContext(KeybindingContext.Global);
+        Assert.Single(bindings);
+        Assert.Equal(Key.F1, bindings[0].Key);
+    }
+
+    [Fact]
+    public void Register_WithNullHandler_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            manager.Register(
+                KeybindingContext.Global,
+                Key.Enter,
+                "Test",
+                "Test description",
+                null!));
+    }
+
+    [Fact]
+    public void Register_ReturnsManagerForFluentChaining()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+
+        // Act
+        var result = manager.Register(
+            KeybindingContext.Global,
+            Key.F1,
+            "Help",
+            "Help description",
+            () => { });
+
+        // Assert
+        Assert.Same(manager, result);
+    }
+
+    [Fact]
+    public void Register_DuplicateKey_ReplacesExistingBinding()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        var firstExecuted = false;
+        var secondExecuted = false;
+
+        // Act - Register same key twice
+        manager.Register(
+            KeybindingContext.AddressSpace,
+            Key.Enter,
+            "First",
+            "First binding",
+            () => firstExecuted = true);
+
+        manager.Register(
+            KeybindingContext.AddressSpace,
+            Key.Enter,
+            "Second",
+            "Second binding",
+            () => secondExecuted = true);
+
+        // Assert - Only one binding should exist with the second handler
+        var bindings = manager.GetBindingsForContext(KeybindingContext.AddressSpace);
+        Assert.Single(bindings);
+        Assert.Equal("Second", bindings[0].Label);
+
+        // Execute and verify second handler is called
+        manager.CurrentContext = KeybindingContext.AddressSpace;
+        manager.TryHandle(Key.Enter);
+        Assert.False(firstExecuted);
+        Assert.True(secondExecuted);
+    }
+
+    [Fact]
+    public void Register_SameKeyDifferentContexts_BothRegistered()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+
+        // Act
+        manager.Register(KeybindingContext.AddressSpace, Key.Enter, "Subscribe", "Subscribe", () => { });
+        manager.Register(KeybindingContext.MonitoredVariables, Key.Enter, "Edit", "Edit value", () => { });
+
+        // Assert
+        Assert.Single(manager.GetBindingsForContext(KeybindingContext.AddressSpace));
+        Assert.Single(manager.GetBindingsForContext(KeybindingContext.MonitoredVariables));
+    }
+
+    #endregion
+
+    #region Context Switching Tests
+
+    [Fact]
+    public void CurrentContext_CanBeSet()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+
+        // Act
+        manager.CurrentContext = KeybindingContext.AddressSpace;
+
+        // Assert
+        Assert.Equal(KeybindingContext.AddressSpace, manager.CurrentContext);
+    }
+
+    [Fact]
+    public void TryHandle_ContextSpecificBindingTakesPrecedence()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        var globalExecuted = false;
+        var contextExecuted = false;
+
+        manager.RegisterGlobal(Key.Enter, "Global", "Global action", () => globalExecuted = true);
+        manager.Register(KeybindingContext.AddressSpace, Key.Enter, "Context", "Context action", () => contextExecuted = true);
+
+        manager.CurrentContext = KeybindingContext.AddressSpace;
+
+        // Act
+        var handled = manager.TryHandle(Key.Enter);
+
+        // Assert
+        Assert.True(handled);
+        Assert.False(globalExecuted);
+        Assert.True(contextExecuted);
+    }
+
+    [Fact]
+    public void TryHandle_FallsBackToGlobalWhenNoContextBinding()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        var globalExecuted = false;
+
+        manager.RegisterGlobal(Key.F1, "Help", "Show help", () => globalExecuted = true);
+        manager.CurrentContext = KeybindingContext.AddressSpace;
+
+        // Act
+        var handled = manager.TryHandle(Key.F1);
+
+        // Assert
+        Assert.True(handled);
+        Assert.True(globalExecuted);
+    }
+
+    [Fact]
+    public void TryHandle_ReturnsFalseWhenNoMatchingBinding()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        manager.RegisterGlobal(Key.F1, "Help", "Help", () => { });
+
+        // Act
+        var handled = manager.TryHandle(Key.F2);
+
+        // Assert
+        Assert.False(handled);
+    }
+
+    [Fact]
+    public void TryHandle_GlobalContextOnlyChecksGlobal()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        var executed = false;
+
+        manager.RegisterGlobal(Key.F1, "Help", "Help", () => executed = true);
+        manager.CurrentContext = KeybindingContext.Global;
+
+        // Act
+        var handled = manager.TryHandle(Key.F1);
+
+        // Assert
+        Assert.True(handled);
+        Assert.True(executed);
+    }
+
+    #endregion
+
+    #region GetActiveBindings Tests
+
+    [Fact]
+    public void GetActiveBindings_IncludesContextAndGlobalBindings()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        manager.RegisterGlobal(Key.F1, "Help", "Help", () => { });
+        manager.Register(KeybindingContext.AddressSpace, Key.Enter, "Subscribe", "Subscribe", () => { });
+
+        manager.CurrentContext = KeybindingContext.AddressSpace;
+
+        // Act
+        var bindings = manager.GetActiveBindings().ToList();
+
+        // Assert
+        Assert.Equal(2, bindings.Count);
+    }
+
+    [Fact]
+    public void GetActiveBindings_OrderedByStatusBarPriority()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        manager.RegisterGlobal(Key.F1, "Low", "Low priority", () => { }, statusBarPriority: 100);
+        manager.RegisterGlobal(Key.F2, "High", "High priority", () => { }, statusBarPriority: 1);
+        manager.RegisterGlobal(Key.F3, "Medium", "Medium priority", () => { }, statusBarPriority: 50);
+
+        // Act
+        var bindings = manager.GetActiveBindings().ToList();
+
+        // Assert
+        Assert.Equal("High", bindings[0].Label);
+        Assert.Equal("Medium", bindings[1].Label);
+        Assert.Equal("Low", bindings[2].Label);
+    }
+
+    [Fact]
+    public void GetActiveBindings_WhenGlobalContext_ReturnsOnlyGlobals()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        manager.RegisterGlobal(Key.F1, "Help", "Help", () => { });
+        manager.Register(KeybindingContext.AddressSpace, Key.Enter, "Subscribe", "Subscribe", () => { });
+
+        manager.CurrentContext = KeybindingContext.Global;
+
+        // Act
+        var bindings = manager.GetActiveBindings().ToList();
+
+        // Assert
+        Assert.Single(bindings);
+        Assert.Equal("Help", bindings[0].Label);
+    }
+
+    #endregion
+
+    #region GetStatusBarBindings Tests
+
+    [Fact]
+    public void GetStatusBarBindings_FiltersNonStatusBarBindings()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        manager.RegisterGlobal(Key.F1, "Visible", "Visible", () => { }, showInStatusBar: true);
+        manager.RegisterGlobal(Key.F2, "Hidden", "Hidden", () => { }, showInStatusBar: false);
+
+        // Act
+        var bindings = manager.GetStatusBarBindings().ToList();
+
+        // Assert
+        Assert.Single(bindings);
+        Assert.Equal("Visible", bindings[0].Label);
+    }
+
+    [Fact]
+    public void GetStatusBarBindings_LimitedToMaxStatusBarShortcuts()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        for (int i = 0; i < 10; i++)
+        {
+            manager.RegisterGlobal(
+                Key.F1.WithCtrl | (Key)('0' + i),
+                $"Binding{i}",
+                $"Binding {i}",
+                () => { },
+                showInStatusBar: true,
+                statusBarPriority: i);
+        }
+
+        // Act
+        var bindings = manager.GetStatusBarBindings().ToList();
+
+        // Assert
+        Assert.Equal(KeybindingManager.MaxStatusBarShortcuts, bindings.Count);
+    }
+
+    [Fact]
+    public void MaxStatusBarShortcuts_IsSix()
+    {
+        // Assert
+        Assert.Equal(6, KeybindingManager.MaxStatusBarShortcuts);
+    }
+
+    #endregion
+
+    #region GetBindingsForContext Tests
+
+    [Fact]
+    public void GetBindingsForContext_ReturnsReadOnlyCollection()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        manager.Register(KeybindingContext.AddressSpace, Key.Enter, "Test", "Test", () => { });
+
+        // Act
+        var bindings = manager.GetBindingsForContext(KeybindingContext.AddressSpace);
+
+        // Assert
+        Assert.IsAssignableFrom<IReadOnlyList<Keybinding>>(bindings);
+    }
+
+    [Fact]
+    public void GetBindingsForContext_ReturnsOnlySpecifiedContext()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        manager.Register(KeybindingContext.AddressSpace, Key.Enter, "AddressSpace", "AddressSpace", () => { });
+        manager.Register(KeybindingContext.MonitoredVariables, Key.Delete, "MonitoredVars", "MonitoredVars", () => { });
+
+        // Act
+        var addressSpaceBindings = manager.GetBindingsForContext(KeybindingContext.AddressSpace);
+        var monitoredVarsBindings = manager.GetBindingsForContext(KeybindingContext.MonitoredVariables);
+
+        // Assert
+        Assert.Single(addressSpaceBindings);
+        Assert.Equal("AddressSpace", addressSpaceBindings[0].Label);
+        Assert.Single(monitoredVarsBindings);
+        Assert.Equal("MonitoredVars", monitoredVarsBindings[0].Label);
+    }
+
+    #endregion
+
+    #region Event Tests
+
+    [Fact]
+    public void KeybindingExecuted_FiredWhenKeybindingHandled()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        Keybinding? executedBinding = null;
+
+        manager.RegisterGlobal(Key.F1, "Help", "Help", () => { });
+        manager.KeybindingExecuted += binding => executedBinding = binding;
+
+        // Act
+        manager.TryHandle(Key.F1);
+
+        // Assert
+        Assert.NotNull(executedBinding);
+        Assert.Equal("Help", executedBinding.Label);
+    }
+
+    [Fact]
+    public void KeybindingExecuted_NotFiredWhenNoMatch()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        var eventFired = false;
+
+        manager.RegisterGlobal(Key.F1, "Help", "Help", () => { });
+        manager.KeybindingExecuted += _ => eventFired = true;
+
+        // Act
+        manager.TryHandle(Key.F2);
+
+        // Assert
+        Assert.False(eventFired);
+    }
+
+    #endregion
+
+    #region Help Generation Tests
+
+    [Fact]
+    public void GenerateContextHelp_IncludesContextName()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        manager.CurrentContext = KeybindingContext.AddressSpace;
+
+        // Act
+        var help = manager.GenerateContextHelp();
+
+        // Assert
+        Assert.Contains("[Address Space]", help);
+    }
+
+    [Fact]
+    public void GenerateFullHelp_GroupsByCategory()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        manager.RegisterGlobal(Key.F1, "Help", "Help", () => { }, category: "Application");
+        manager.Register(KeybindingContext.AddressSpace, Key.Enter, "Subscribe", "Subscribe", () => { }, category: "Navigation");
+
+        // Act
+        var help = manager.GenerateFullHelp();
+
+        // Assert
+        Assert.Contains("APPLICATION", help);
+        Assert.Contains("NAVIGATION", help);
+    }
+
+    [Fact]
+    public void GetContextDisplayName_ReturnsHumanReadableNames()
+    {
+        // Assert
+        Assert.Equal("Global", KeybindingManager.GetContextDisplayName(KeybindingContext.Global));
+        Assert.Equal("Address Space", KeybindingManager.GetContextDisplayName(KeybindingContext.AddressSpace));
+        Assert.Equal("Monitored Variables", KeybindingManager.GetContextDisplayName(KeybindingContext.MonitoredVariables));
+        Assert.Equal("Scope View", KeybindingManager.GetContextDisplayName(KeybindingContext.Scope));
+        Assert.Equal("Trend Plot", KeybindingManager.GetContextDisplayName(KeybindingContext.TrendPlot));
+        Assert.Equal("Dialog", KeybindingManager.GetContextDisplayName(KeybindingContext.Dialog));
+    }
+
+    #endregion
+
+    #region GetAllBindingsGroupedByCategory Tests
+
+    [Fact]
+    public void GetAllBindingsGroupedByCategory_GroupsCorrectly()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        manager.RegisterGlobal(Key.F1, "Help1", "Help 1", () => { }, category: "Application");
+        manager.RegisterGlobal(Key.F2, "Help2", "Help 2", () => { }, category: "Application");
+        manager.Register(KeybindingContext.AddressSpace, Key.Enter, "Sub", "Subscribe", () => { }, category: "Navigation");
+
+        // Act
+        var groups = manager.GetAllBindingsGroupedByCategory().ToList();
+
+        // Assert
+        Assert.Equal(2, groups.Count);
+
+        var navigationGroup = groups.First(g => g.Key == "Navigation");
+        var applicationGroup = groups.First(g => g.Key == "Application");
+
+        Assert.Single(navigationGroup);
+        Assert.Equal(2, applicationGroup.Count());
+    }
+
+    #endregion
+
+    #region GetAllBindingsGroupedByContext Tests
+
+    [Fact]
+    public void GetAllBindingsGroupedByContext_GroupsCorrectly()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        manager.RegisterGlobal(Key.F1, "Help", "Help", () => { });
+        manager.Register(KeybindingContext.AddressSpace, Key.Enter, "Sub", "Subscribe", () => { });
+        manager.Register(KeybindingContext.AddressSpace, Key.F5, "Refresh", "Refresh", () => { });
+
+        // Act
+        var groups = manager.GetAllBindingsGroupedByContext().ToList();
+
+        // Assert
+        Assert.Equal(2, groups.Count);
+
+        var globalGroup = groups.First(g => g.Key == KeybindingContext.Global);
+        var addressSpaceGroup = groups.First(g => g.Key == KeybindingContext.AddressSpace);
+
+        Assert.Single(globalGroup);
+        Assert.Equal(2, addressSpaceGroup.Count());
+    }
+
+    [Fact]
+    public void GetAllBindingsGroupedByContext_ExcludesEmptyContexts()
+    {
+        // Arrange
+        var manager = new KeybindingManager();
+        manager.RegisterGlobal(Key.F1, "Help", "Help", () => { });
+
+        // Act
+        var groups = manager.GetAllBindingsGroupedByContext().ToList();
+
+        // Assert
+        Assert.Single(groups);
+        Assert.Equal(KeybindingContext.Global, groups[0].Key);
+    }
+
+    #endregion
+}

--- a/tests/Opcilloscope.Tests/App/Keybindings/KeybindingTests.cs
+++ b/tests/Opcilloscope.Tests/App/Keybindings/KeybindingTests.cs
@@ -1,0 +1,493 @@
+using Opcilloscope.App.Keybindings;
+using Terminal.Gui;
+
+namespace Opcilloscope.Tests.App.Keybindings;
+
+public class KeybindingTests
+{
+    #region Constructor Tests
+
+    [Fact]
+    public void Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var executed = false;
+        Action handler = () => executed = true;
+
+        // Act
+        var binding = new Keybinding(
+            KeybindingContext.AddressSpace,
+            Key.Enter,
+            "Subscribe",
+            "Subscribe to the selected node",
+            handler,
+            showInStatusBar: true,
+            statusBarPriority: 50,
+            category: "Navigation");
+
+        // Assert
+        Assert.Equal(KeybindingContext.AddressSpace, binding.Context);
+        Assert.Equal(Key.Enter, binding.Key);
+        Assert.Equal("Subscribe", binding.Label);
+        Assert.Equal("Subscribe to the selected node", binding.Description);
+        Assert.True(binding.ShowInStatusBar);
+        Assert.Equal(50, binding.StatusBarPriority);
+        Assert.Equal("Navigation", binding.Category);
+
+        // Verify handler
+        binding.Handler();
+        Assert.True(executed);
+    }
+
+    [Fact]
+    public void Constructor_DefaultValues()
+    {
+        // Act
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.F1,
+            "Help",
+            "Show help",
+            () => { });
+
+        // Assert
+        Assert.True(binding.ShowInStatusBar);
+        Assert.Equal(100, binding.StatusBarPriority);
+        Assert.Equal("General", binding.Category);
+    }
+
+    #endregion
+
+    #region Matches Tests
+
+    [Fact]
+    public void Matches_SameKey_ReturnsTrue()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.F1,
+            "Help",
+            "Help",
+            () => { });
+
+        // Act & Assert
+        Assert.True(binding.Matches(Key.F1));
+    }
+
+    [Fact]
+    public void Matches_DifferentKey_ReturnsFalse()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.F1,
+            "Help",
+            "Help",
+            () => { });
+
+        // Act & Assert
+        Assert.False(binding.Matches(Key.F2));
+    }
+
+    [Fact]
+    public void Matches_CharacterKey_MatchesExactly()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            (Key)'w',
+            "Write",
+            "Write value",
+            () => { });
+
+        // Act & Assert
+        Assert.True(binding.Matches((Key)'w'));
+        Assert.False(binding.Matches((Key)'W')); // Case sensitive
+    }
+
+    [Fact]
+    public void Matches_ModifierKey_RequiresExactModifiers()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.S.WithCtrl,
+            "Save",
+            "Save file",
+            () => { });
+
+        // Act & Assert
+        Assert.True(binding.Matches(Key.S.WithCtrl));
+        Assert.False(binding.Matches(Key.S)); // Without Ctrl
+        Assert.False(binding.Matches(Key.S.WithAlt)); // Different modifier
+    }
+
+    [Fact]
+    public void Matches_MultipleModifiers_RequiresAllModifiers()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.S.WithCtrl.WithShift,
+            "SaveAs",
+            "Save file as",
+            () => { });
+
+        // Act & Assert
+        Assert.True(binding.Matches(Key.S.WithCtrl.WithShift));
+        Assert.False(binding.Matches(Key.S.WithCtrl)); // Missing Shift
+        Assert.False(binding.Matches(Key.S.WithShift)); // Missing Ctrl
+    }
+
+    [Fact]
+    public void Matches_Enter_MatchesEnterKey()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.AddressSpace,
+            Key.Enter,
+            "Subscribe",
+            "Subscribe",
+            () => { });
+
+        // Act & Assert
+        Assert.True(binding.Matches(Key.Enter));
+    }
+
+    [Fact]
+    public void Matches_Space_MatchesSpaceKey()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.MonitoredVariables,
+            Key.Space,
+            "Select",
+            "Toggle selection",
+            () => { });
+
+        // Act & Assert
+        Assert.True(binding.Matches(Key.Space));
+    }
+
+    [Fact]
+    public void Matches_Delete_MatchesDeleteKey()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.MonitoredVariables,
+            Key.Delete,
+            "Unsub",
+            "Unsubscribe",
+            () => { });
+
+        // Act & Assert
+        Assert.True(binding.Matches(Key.Delete));
+    }
+
+    [Fact]
+    public void Matches_Tab_MatchesTabKey()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.Tab,
+            "Switch",
+            "Switch panes",
+            () => { });
+
+        // Act & Assert
+        Assert.True(binding.Matches(Key.Tab));
+    }
+
+    #endregion
+
+    #region KeyDisplay / FormatKey Tests
+
+    [Theory]
+    [InlineData(KeyCode.F1, "F1")]
+    [InlineData(KeyCode.F2, "F2")]
+    [InlineData(KeyCode.F5, "F5")]
+    [InlineData(KeyCode.F10, "F10")]
+    [InlineData(KeyCode.F12, "F12")]
+    public void KeyDisplay_FunctionKeys_FormatsCorrectly(KeyCode keyCode, string expected)
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            new Key(keyCode),
+            "Test",
+            "Test",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal(expected, binding.KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_Enter_FormatsAsEnter()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.Enter,
+            "Test",
+            "Test",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal("Enter", binding.KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_Space_FormatsAsSpace()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.Space,
+            "Test",
+            "Test",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal("Space", binding.KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_Tab_FormatsAsTab()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.Tab,
+            "Test",
+            "Test",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal("Tab", binding.KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_Delete_FormatsAsDelete()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.Delete,
+            "Test",
+            "Test",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal("Delete", binding.KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_Escape_FormatsAsEsc()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.Esc,
+            "Test",
+            "Test",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal("Esc", binding.KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_Backspace_FormatsAsBackspace()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.Backspace,
+            "Test",
+            "Test",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal("Backspace", binding.KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_ArrowKeys_FormatsWithUnicodeSymbols()
+    {
+        // Arrange & Assert
+        Assert.Equal("↑", CreateBinding(Key.CursorUp).KeyDisplay);
+        Assert.Equal("↓", CreateBinding(Key.CursorDown).KeyDisplay);
+        Assert.Equal("←", CreateBinding(Key.CursorLeft).KeyDisplay);
+        Assert.Equal("→", CreateBinding(Key.CursorRight).KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_HomeEnd_FormatsCorrectly()
+    {
+        // Assert
+        Assert.Equal("Home", CreateBinding(Key.Home).KeyDisplay);
+        Assert.Equal("End", CreateBinding(Key.End).KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_PageUpDown_FormatsAsPgUpPgDn()
+    {
+        // Assert
+        Assert.Equal("PgUp", CreateBinding(Key.PageUp).KeyDisplay);
+        Assert.Equal("PgDn", CreateBinding(Key.PageDown).KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_CtrlModifier_FormatsWithCtrlPrefix()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.S.WithCtrl,
+            "Save",
+            "Save",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal("Ctrl+S", binding.KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_ShiftModifier_FormatsWithShiftPrefix()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.S.WithShift,
+            "Test",
+            "Test",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal("Shift+S", binding.KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_AltModifier_FormatsWithAltPrefix()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.S.WithAlt,
+            "Test",
+            "Test",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal("Alt+S", binding.KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_CtrlShiftModifiers_FormatsWithBothPrefixes()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.S.WithCtrl.WithShift,
+            "SaveAs",
+            "Save As",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal("Ctrl+Shift+S", binding.KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_AllModifiers_FormatsWithAllPrefixes()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            Key.S.WithCtrl.WithShift.WithAlt,
+            "Test",
+            "Test",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal("Ctrl+Shift+Alt+S", binding.KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_CharacterKey_FormatsAsUppercase()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            (Key)'w',
+            "Write",
+            "Write",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal("W", binding.KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_PlusKey_FormatsCorrectly()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Scope,
+            (Key)'+',
+            "Zoom+",
+            "Zoom in",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal("+", binding.KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_MinusKey_FormatsCorrectly()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Scope,
+            (Key)'-',
+            "Zoom-",
+            "Zoom out",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal("-", binding.KeyDisplay);
+    }
+
+    [Fact]
+    public void KeyDisplay_QuestionMark_FormatsCorrectly()
+    {
+        // Arrange
+        var binding = new Keybinding(
+            KeybindingContext.Global,
+            (Key)'?',
+            "Help",
+            "Quick help",
+            () => { });
+
+        // Act & Assert
+        Assert.Equal("?", binding.KeyDisplay);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static Keybinding CreateBinding(Key key)
+    {
+        return new Keybinding(
+            KeybindingContext.Global,
+            key,
+            "Test",
+            "Test description",
+            () => { });
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Implement a context-aware keybinding system inspired by lazygit:

- KeybindingContext enum for view contexts (Global, AddressSpace,
  MonitoredVariables, Scope, TrendPlot, Dialog)
- Keybinding class with key, label, description, handler, and
  display formatting
- KeybindingManager with context-aware resolution (context > global)
  and auto-generation of help text
- DefaultKeybindings factory configuring all standard shortcuts
- QuickHelpDialog (?) showing context-sensitive keybindings overlay
- Updated HelpDialog to auto-generate from KeybindingManager
- Status bar now dynamically updates based on active context

Key features from lazygit:
- Hierarchical keybinding resolution (context-specific > global)
- Press ? for context-sensitive quick help
- Status bar shows shortcuts for current view
- Single source of truth for all keybindings