### PR TITLE
Reorganize and expand keyboard shortcuts documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,44 @@ Requires [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0).
 
 opcilloscope is designed for keyboard-first workflows:
 
+**Global:**
+
 | Key | Action |
 |-----|--------|
-| `Ctrl+O` | Connect to server |
-| `Enter` | Subscribe to selected node |
-| `Delete` | Unsubscribe |
-| `F5` | Refresh address space |
-| `F1` | Help |
-| `F10` | Menu |
-| `Tab` | Switch panels |
+| `?` | Show help |
+| `M` | Open menu |
+| `Tab` | Switch between panes |
+| `Ctrl+O` | Open configuration |
+| `Ctrl+S` | Save configuration |
+| `Ctrl+Shift+S` | Save configuration as |
+| `Ctrl+R` | Toggle recording (start/stop) |
 | `Ctrl+Q` | Quit |
+
+**Address Space:**
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Subscribe to selected node |
+| `R` | Refresh address space tree |
+
+**Monitored Variables:**
+
+| Key | Action |
+|-----|--------|
+| `Delete` | Unsubscribe from selected variable |
+| `Space` | Toggle selection (for Scope/Recording) |
+| `W` | Write value to selected variable |
+| `T` | Show trend plot |
+| `S` | Open Scope with selected variables |
+
+**Scope/Trend Plot View:**
+
+| Key | Action |
+|-----|--------|
+| `Space` | Pause/resume plotting |
+| `+`/`=` | Zoom in (increase scale) |
+| `-` | Zoom out (decrease scale) |
+| `R` | Reset to auto-scale |
 
 ---
 


### PR DESCRIPTION
## Summary
Updated the keyboard shortcuts documentation in README.md to be more comprehensive and better organized by context/pane.

## Key Changes
- Reorganized shortcuts into logical sections: Global, Address Space, Monitored Variables, and Scope/Trend Plot View
- Added new keyboard shortcuts that were previously undocumented:
  - `?` for help (replacing `F1`)
  - `M` for menu (replacing `F10`)
  - `Ctrl+S` and `Ctrl+Shift+S` for saving configurations
  - `Ctrl+R` for recording toggle
  - `R` for refresh address space (replacing `F5`)
  - `Space` for selection toggle and pause/resume
  - `W` for writing values
  - `T` for trend plot
  - `S` for opening Scope
  - `+`/`=` and `-` for zoom controls
  - `R` for auto-scale reset
- Removed deprecated shortcuts (`F1`, `F5`, `F10`)
- Improved clarity with more descriptive action labels (e.g., "Switch between panes" instead of "Switch panels")

## Notes
This documentation update reflects the current state of keyboard shortcuts in the application and makes it easier for users to discover available commands by grouping them by context.