### PR TITLE
Remove hardcoded quick help shortcut from status bar

### DIFF
--- a/App/MainWindow.cs
+++ b/App/MainWindow.cs
@@ -625,9 +625,6 @@ public class MainWindow : Toplevel, DefaultKeybindings.IKeybindingActions
             _statusBar.Add(new Shortcut(binding.Key, binding.Label, binding.Handler));
         }
 
-        // Add ? hint for quick help (always show)
-        _statusBar.Add(new Shortcut((Key)'?', "?", ShowQuickHelp));
-
         _statusBar.SetNeedsLayout();
     }
 


### PR DESCRIPTION
## Summary
Removed the hardcoded "?" quick help shortcut that was always displayed in the status bar during `UpdateStatusBarShortcuts()`.

## Changes
- Removed the automatic addition of the "?" (quick help) shortcut to the status bar
- This shortcut was previously always shown regardless of other status bar configuration

## Details
The quick help shortcut was being unconditionally added to the status bar in the `UpdateStatusBarShortcuts()` method. This change removes that hardcoded behavior, allowing the status bar shortcuts to be managed more flexibly through the binding configuration system rather than having this shortcut forced in at all times.