### PR TITLE
Persist last endpoint URL in ConnectDialog

### DIFF
--- a/App/Dialogs/ConnectDialog.cs
+++ b/App/Dialogs/ConnectDialog.cs
@@ -17,7 +17,7 @@ public class ConnectDialog : Dialog
     public string EndpointUrl => _endpointField.Text ?? string.Empty;
     public bool Confirmed => _confirmed;
 
-    public ConnectDialog()
+    public ConnectDialog(string? initialEndpoint = null)
     {
         var theme = AppThemeManager.Current;
 
@@ -45,7 +45,7 @@ public class ConnectDialog : Dialog
             X = 1,
             Y = 2,
             Width = Dim.Fill(1),
-            Text = string.Empty
+            Text = initialEndpoint ?? string.Empty
         };
 
         var hintLabel = new Label

--- a/App/MainWindow.cs
+++ b/App/MainWindow.cs
@@ -430,7 +430,7 @@ public class MainWindow : Toplevel, DefaultKeybindings.IKeybindingActions
 
     private void ShowConnectDialog()
     {
-        var dialog = new ConnectDialog();
+        var dialog = new ConnectDialog(_lastEndpoint);
         Application.Run(dialog);
 
         if (dialog.Confirmed)


### PR DESCRIPTION
## Summary
Enhanced the ConnectDialog to remember and restore the last used endpoint URL, improving user experience by eliminating the need to re-enter the same endpoint on subsequent connections.

## Changes
- Modified `ConnectDialog` constructor to accept an optional `initialEndpoint` parameter
- Updated the endpoint text field to populate with the provided initial endpoint value instead of always starting empty
- Modified `MainWindow.ShowConnectDialog()` to pass the stored `_lastEndpoint` when creating a new ConnectDialog instance

## Implementation Details
- The `initialEndpoint` parameter defaults to `null`, maintaining backward compatibility
- Uses null-coalescing operator (`??`) to fall back to empty string if no initial endpoint is provided
- The last endpoint value is persisted in the MainWindow and reused across dialog instances