### PR TITLE
Update ConnectionIdentifier format: use hyphen for host-port separator

### DIFF
--- a/Tests/Opcilloscope.Tests/Utilities/ConnectionIdentifierTests.cs
+++ b/Tests/Opcilloscope.Tests/Utilities/ConnectionIdentifierTests.cs
@@ -14,7 +14,7 @@ public class ConnectionIdentifierTests
         var result = ConnectionIdentifier.Generate("opc.tcp://192.168.1.67:50000", timestamp);
 
         // Assert
-        Assert.Equal("192.168.1.67_50000_202601071234", result);
+        Assert.Equal("192.168.1.67-50000_20260107_1234", result);
     }
 
     [Fact]
@@ -27,7 +27,7 @@ public class ConnectionIdentifierTests
         var result = ConnectionIdentifier.Generate("opc.tcp://localhost:4840", timestamp);
 
         // Assert
-        Assert.Equal("localhost_4840_202601071234", result);
+        Assert.Equal("localhost-4840_20260107_1234", result);
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class ConnectionIdentifierTests
         var result = ConnectionIdentifier.Generate("opc.tcp://server:4840/UA/MyServer", timestamp);
 
         // Assert
-        Assert.Equal("server_4840_202601071234", result);
+        Assert.Equal("server-4840_20260107_1234", result);
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class ConnectionIdentifierTests
         var result = ConnectionIdentifier.Generate(null, timestamp);
 
         // Assert
-        Assert.Equal("config_202601071234", result);
+        Assert.Equal("config_20260107_1234", result);
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class ConnectionIdentifierTests
         var result = ConnectionIdentifier.Generate("", timestamp);
 
         // Assert
-        Assert.Equal("config_202601071234", result);
+        Assert.Equal("config_20260107_1234", result);
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class ConnectionIdentifierTests
         var result = ConnectionIdentifier.Generate("opc.tcp://localhost:4840", timestamp, "yyyyMMddHHmmss");
 
         // Assert
-        Assert.Equal("localhost_4840_20260107123456", result);
+        Assert.Equal("localhost-4840_20260107123456", result);
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class ConnectionIdentifierTests
         var result = ConnectionIdentifier.ExtractHostPort("opc.tcp://192.168.1.67:50000");
 
         // Assert
-        Assert.Equal("192.168.1.67_50000", result);
+        Assert.Equal("192.168.1.67-50000", result);
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public class ConnectionIdentifierTests
         var result = ConnectionIdentifier.ExtractHostPort("opc.https://server.example.com:443");
 
         // Assert
-        Assert.Equal("server.example.com_443", result);
+        Assert.Equal("server.example.com-443", result);
     }
 
     [Fact]
@@ -109,7 +109,7 @@ public class ConnectionIdentifierTests
         var result = ConnectionIdentifier.ExtractHostPort("https://server.example.com:443");
 
         // Assert
-        Assert.Equal("server.example.com_443", result);
+        Assert.Equal("server.example.com-443", result);
     }
 
     [Fact]
@@ -119,7 +119,7 @@ public class ConnectionIdentifierTests
         var result = ConnectionIdentifier.ExtractHostPort("opc.tcp://server:4840/UA/MyServer");
 
         // Assert
-        Assert.Equal("server_4840", result);
+        Assert.Equal("server-4840", result);
     }
 
     [Fact]
@@ -159,7 +159,7 @@ public class ConnectionIdentifierTests
         var result = ConnectionIdentifier.ExtractHostPort("opc.tcp://10.0.0.1:4840");
 
         // Assert
-        Assert.Equal("10.0.0.1_4840", result);
+        Assert.Equal("10.0.0.1-4840", result);
     }
 
     [Fact]
@@ -206,28 +206,28 @@ public class ConnectionIdentifierTests
         var result = ConnectionIdentifier.Generate("opc.tcp://localhost:4840");
         var after = DateTime.Now;
 
-        // Assert - should contain a 12-digit timestamp
-        Assert.Matches(@"localhost_4840_\d{12}$", result);
+        // Assert - should contain a timestamp in format yyyyMMdd_HHmm
+        Assert.Matches(@"localhost-4840_\d{8}_\d{4}$", result);
 
         // Verify the timestamp is within the expected range
-        var expectedPrefix = "localhost_4840_";
+        var expectedPrefix = "localhost-4840_";
         var timestampPart = result.Substring(expectedPrefix.Length);
-        var parsedTimestamp = DateTime.ParseExact(timestampPart, "yyyyMMddHHmm", null);
+        var parsedTimestamp = DateTime.ParseExact(timestampPart, "yyyyMMdd_HHmm", null);
         Assert.True(parsedTimestamp >= before.AddSeconds(-60) && parsedTimestamp <= after.AddSeconds(60));
     }
 
     [Fact]
-    public void ExtractHostPort_EnsuresUnderscoreBetweenIpAndPort()
+    public void ExtractHostPort_EnsuresHyphenBetweenIpAndPort()
     {
         // This tests the specific issue mentioned in the task:
-        // IP and port should be separated by underscore
+        // IP and port should be separated by hyphen
 
         // Act
         var result = ConnectionIdentifier.ExtractHostPort("opc.tcp://192.168.1.67:50000");
 
-        // Assert - verify there's an underscore between IP and port
-        Assert.Equal("192.168.1.67_50000", result);
-        Assert.Contains("_", result);
+        // Assert - verify there's a hyphen between IP and port
+        Assert.Equal("192.168.1.67-50000", result);
+        Assert.Contains("-", result);
         Assert.DoesNotContain("6750000", result); // This would be the bug case
     }
 }

--- a/Utilities/ConnectionIdentifier.cs
+++ b/Utilities/ConnectionIdentifier.cs
@@ -2,19 +2,19 @@ namespace Opcilloscope.Utilities;
 
 /// <summary>
 /// Utility for generating standardized connection identifier strings.
-/// Format: {host}_{port}_{timestamp} with underscores separating each component.
+/// Format: {host}-{port}_{date}_{time} with hyphen between host/port and underscores for timestamp.
 /// </summary>
 public static class ConnectionIdentifier
 {
     /// <summary>
     /// Generates a standardized connection identifier string from an endpoint URL.
-    /// Format: {host}_{port}_{timestamp}
+    /// Format: {host}-{port}_{date}_{time}
     /// </summary>
     /// <param name="endpointUrl">The OPC UA endpoint URL (e.g., "opc.tcp://192.168.1.67:50000").</param>
     /// <param name="timestamp">Optional timestamp. If null, uses current time.</param>
-    /// <param name="timestampFormat">Format string for the timestamp. Default is "yyyyMMddHHmm".</param>
-    /// <returns>A standardized identifier string (e.g., "192.168.1.67_50000_202601071234").</returns>
-    public static string Generate(string? endpointUrl, DateTime? timestamp = null, string timestampFormat = "yyyyMMddHHmm")
+    /// <param name="timestampFormat">Format string for the timestamp. Default is "yyyyMMdd_HHmm".</param>
+    /// <returns>A standardized identifier string (e.g., "192.168.1.67-50000_20260107_1234").</returns>
+    public static string Generate(string? endpointUrl, DateTime? timestamp = null, string timestampFormat = "yyyyMMdd_HHmm")
     {
         var ts = (timestamp ?? DateTime.Now).ToString(timestampFormat);
 
@@ -27,10 +27,10 @@ public static class ConnectionIdentifier
 
     /// <summary>
     /// Extracts the host and port from an endpoint URL in a filename-safe format.
-    /// Format: {host}_{port}
+    /// Format: {host}-{port}
     /// </summary>
     /// <param name="endpointUrl">The OPC UA endpoint URL.</param>
-    /// <returns>A filename-safe string with host and port separated by underscore.</returns>
+    /// <returns>A filename-safe string with host and port separated by hyphen.</returns>
     public static string ExtractHostPort(string? endpointUrl)
     {
         if (string.IsNullOrEmpty(endpointUrl))
@@ -57,7 +57,7 @@ public static class ConnectionIdentifier
             host = SanitizeComponent(host);
             port = SanitizeComponent(port);
 
-            return $"{host}_{port}";
+            return $"{host}-{port}";
         }
 
         // No port specified, just sanitize the host


### PR DESCRIPTION
## Summary
Updates the `ConnectionIdentifier` utility to use a hyphen (`-`) instead of an underscore (`_`) to separate host and port components, and reformats the timestamp portion to use `yyyyMMdd_HHmm` format for better readability.

## Changes
- **Separator change**: Host and port are now separated by hyphen (`-`) instead of underscore (`_`)
  - Example: `192.168.1.67-50000` instead of `192.168.1.67_50000`
- **Timestamp format**: Updated default timestamp format from `yyyyMMddHHmm` to `yyyyMMdd_HHmm`
  - Separates date and time components with an underscore for improved readability
  - Example: `20260107_1234` instead of `202601071234`
- **Overall identifier format**: Now follows pattern `{host}-{port}_{date}_{time}`
  - Example: `192.168.1.67-50000_20260107_1234`

## Implementation Details
- Updated `ConnectionIdentifier.Generate()` method's default `timestampFormat` parameter
- Modified `ExtractHostPort()` method to use hyphen separator
- Updated all test cases to reflect the new format
- Updated XML documentation comments to reflect the new format specification
- The hyphen separator provides better visual distinction between host/port components while maintaining filename safety

## Testing
All existing tests have been updated to validate the new format, including:
- Basic URL parsing with various protocols (opc.tcp, opc.https, https)
- Localhost and IP address handling
- URL paths (which are correctly ignored)
- Null/empty URL handling
- Custom timestamp format support
- Current time usage when timestamp is not provided