### PR TITLE
Remove menu keybinding (M key) from application

### DIFF
--- a/App/Keybindings/DefaultKeybindings.cs
+++ b/App/Keybindings/DefaultKeybindings.cs
@@ -17,7 +17,6 @@ public static class DefaultKeybindings
         void SwitchPane();
         void ShowHelp();
         void ShowQuickHelp();
-        void OpenMenu();
 
         // Address Space
         void SubscribeSelected();
@@ -70,24 +69,6 @@ public static class DefaultKeybindings
             actions.ShowHelp,
             showInStatusBar: true,
             statusBarPriority: 1,
-            category: "Application");
-
-        manager.RegisterGlobal(
-            (Key)'m',
-            "Menu",
-            "Open menu",
-            actions.OpenMenu,
-            showInStatusBar: true,
-            statusBarPriority: 99,
-            category: "Application");
-
-        manager.RegisterGlobal(
-            (Key)'M',
-            "Menu",
-            "Open menu",
-            actions.OpenMenu,
-            showInStatusBar: false,
-            statusBarPriority: 100,
             category: "Application");
 
         // File operations

--- a/App/MainWindow.cs
+++ b/App/MainWindow.cs
@@ -157,8 +157,6 @@ public class MainWindow : Toplevel, DefaultKeybindings.IKeybindingActions
         // Minimal status bar: only essential shortcuts
         _statusBar.Add(new Shortcut((Key)'?', "Help", ShowHelp));
         _statusBar.Add(new Shortcut((Key)'r', "Refresh", RefreshTree));
-        _statusBar.Add(new Shortcut((Key)'m', "Menu", () => _menuBar.OpenMenu()));
-
         // Connection status indicator (colored) - FAR RIGHT, overlaid on status bar row
         // We position it dynamically based on text width
         _connectionStatusLabel = new Label
@@ -1356,7 +1354,6 @@ License: MIT
     void DefaultKeybindings.IKeybindingActions.SwitchPane() => _focusManager?.FocusNext();
     void DefaultKeybindings.IKeybindingActions.ShowHelp() => ShowHelp();
     void DefaultKeybindings.IKeybindingActions.ShowQuickHelp() => ShowQuickHelp();
-    void DefaultKeybindings.IKeybindingActions.OpenMenu() => _menuBar.OpenMenu();
     void DefaultKeybindings.IKeybindingActions.SubscribeSelected() => SubscribeSelected();
     void DefaultKeybindings.IKeybindingActions.RefreshTree() => RefreshTree();
     void DefaultKeybindings.IKeybindingActions.UnsubscribeSelected() => UnsubscribeSelected();

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,7 +448,6 @@ Automates release builds and publishing.
 | Key | Action |
 |-----|--------|
 | ? | Show help |
-| M | Open menu |
 | Tab | Switch between panes |
 | Ctrl+O | Open configuration |
 | Ctrl+S | Save configuration |

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ opcilloscope is designed for keyboard-first workflows:
 | Key | Action |
 |-----|--------|
 | `?` | Show help |
-| `M` | Open menu |
 | `Tab` | Switch between panes |
 | `Ctrl+O` | Open configuration |
 | `Ctrl+S` | Save configuration |


### PR DESCRIPTION
## Summary
Removes the menu keybinding functionality from the application, including the 'M' and 'Shift+M' key bindings that previously opened the menu.

## Changes Made
- Removed `OpenMenu()` method from `IKeybindingActions` interface in DefaultKeybindings.cs
- Removed global keybinding registrations for 'M' and 'Shift+M' keys that triggered menu opening
- Removed menu shortcut from the status bar in MainWindow.cs
- Removed `OpenMenu()` implementation from MainWindow.cs that delegated to `_menuBar.OpenMenu()`
- Updated documentation (CLAUDE.md and README.md) to remove the 'M' key from the keybindings reference table

## Notes
The menu bar itself remains functional; only the keyboard shortcut to open it has been removed. Users can still access the menu through other means (e.g., mouse interaction or alternative navigation methods).