### PR TITLE
Restrict row selection toggle to "Sel" column only

### DIFF
--- a/App/Views/MonitoredVariablesView.cs
+++ b/App/Views/MonitoredVariablesView.cs
@@ -491,10 +491,11 @@ public class MonitoredVariablesView : FrameView
     private void HandleMouseClick(object? sender, MouseEventArgs e)
     {
         // Convert screen position to table cell
-        var cellPoint = _tableView.ScreenToCell(e.Position.X, e.Position.Y, out int? columnIndex, out int? rowIndex);
+        _tableView.ScreenToCell(e.Position.X, e.Position.Y, out int? columnIndex, out int? rowIndex);
 
-        // Toggle selection when clicking anywhere on a valid row
-        if (rowIndex.HasValue && rowIndex.Value >= 0 && rowIndex.Value < _dataTable.Rows.Count)
+        // Only toggle selection when clicking on the "Sel" column (column 0)
+        if (columnIndex.HasValue && columnIndex.Value == 0 &&
+            rowIndex.HasValue && rowIndex.Value >= 0 && rowIndex.Value < _dataTable.Rows.Count)
         {
             var row = _dataTable.Rows[rowIndex.Value];
             var variable = row["_VariableRef"] as MonitoredNode;


### PR DESCRIPTION
## Summary
Modified the row selection behavior in the Monitored Variables view to only allow toggling selection when clicking on the "Sel" column (column 0), rather than allowing selection toggle on any column in a valid row.

## Changes
- Updated `HandleMouseClick` method to check that the clicked column is specifically column 0 before toggling row selection
- Removed the unused `cellPoint` variable that was returned from `ScreenToCell` call
- Added column index validation to the selection condition alongside existing row index validation

## Implementation Details
The selection logic now requires both:
1. A valid column index equal to 0 (the "Sel" column)
2. A valid row index within the data table bounds

This prevents accidental selection toggles when users click on other columns in the table, improving the user experience by making selection behavior more explicit and predictable.