### PR TITLE
Refactor keyboard shortcuts for tree node interaction

### DIFF
--- a/App/Views/AddressSpaceView.cs
+++ b/App/Views/AddressSpaceView.cs
@@ -190,8 +190,36 @@ public class AddressSpaceView : FrameView
 
     private void HandleKeyDown(object? _, Key e)
     {
-        if (e == Key.Enter || e == Key.Space)
+        if (e == Key.Enter)
         {
+            var selected = _treeView.SelectedObject;
+            if (selected != null)
+            {
+                // Toggle expand/collapse if node has children
+                if (selected.HasChildren)
+                {
+                    if (_treeView.IsExpanded(selected))
+                    {
+                        _treeView.Collapse(selected);
+                    }
+                    else
+                    {
+                        _treeView.Expand(selected);
+                    }
+                }
+
+                // Also subscribe if it's a Variable node
+                if (selected.NodeClass == Opc.Ua.NodeClass.Variable)
+                {
+                    NodeSubscribeRequested?.Invoke(selected);
+                }
+
+                e.Handled = true;
+            }
+        }
+        else if (e == Key.Space)
+        {
+            // Space only subscribes (original behavior for variables)
             var selected = _treeView.SelectedObject;
             if (selected != null && selected.NodeClass == Opc.Ua.NodeClass.Variable)
             {


### PR DESCRIPTION
## Summary
Separated the keyboard shortcut behavior for tree node interaction by assigning distinct actions to the Enter and Space keys. Previously, both keys triggered the same subscription behavior for Variable nodes.

## Key Changes
- **Enter key**: Now toggles node expansion/collapse for nodes with children AND subscribes to Variable nodes
- **Space key**: Retains original behavior of subscribing only to Variable nodes
- Improved code organization by splitting the combined condition into separate handlers for each key

## Implementation Details
- The Enter key handler now includes logic to check if a node has children and toggle its expanded state before attempting subscription
- Both handlers properly null-check the selected node and set `e.Handled = true` to prevent default behavior
- The Space key behavior remains unchanged, maintaining backward compatibility for users relying on that shortcut for subscriptions