### PR TITLE
Normalize assembly name to lowercase

### DIFF
--- a/Opcilloscope.csproj
+++ b/Opcilloscope.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Opcilloscope</RootNamespace>
-    <AssemblyName>Opcilloscope</AssemblyName>
+    <AssemblyName>opcilloscope</AssemblyName>
 
     <!-- Package metadata (Version is driven by MinVer from Git tags) -->
     <Authors>Brett Kinny</Authors>


### PR DESCRIPTION
## Summary
Changed the assembly name from `Opcilloscope` to `opcilloscope` (lowercase) in the project file to follow .NET naming conventions.

## Changes
- Updated `AssemblyName` property in `Opcilloscope.csproj` from `Opcilloscope` to `opcilloscope`

## Details
This change normalizes the assembly name to use lowercase, which is a common convention for .NET assemblies and package names. This will affect the output assembly filename (e.g., `opcilloscope.dll` instead of `Opcilloscope.dll`) and may be part of preparing for NuGet package publishing or aligning with project naming standards.

https://claude.ai/code/session_018Bm3CzzHi7gYSaqCvYn2zN