### PR TITLE
Fix binary detection in install script for case-insensitive filesystems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,14 @@ install() {
 
     info "Installing to ${INSTALL_DIR}..."
     mkdir -p "${INSTALL_DIR}"
-    mv "${tmp_dir}/opcilloscope" "${INSTALL_DIR}/opcilloscope"
+
+    # Find the binary (handle both 'opcilloscope' and 'Opcilloscope' naming)
+    binary=$(find "${tmp_dir}" -maxdepth 1 -type f -iname 'opcilloscope' -not -name '*.pdb' | head -n 1)
+    if [ -z "$binary" ]; then
+        error "Could not find opcilloscope binary in archive"
+    fi
+
+    mv "$binary" "${INSTALL_DIR}/opcilloscope"
     chmod +x "${INSTALL_DIR}/opcilloscope"
 
     # Verify installation


### PR DESCRIPTION
## Summary
Updated the installation script to robustly handle binary detection across different filesystem types and naming conventions, particularly for case-insensitive filesystems where the binary might be named `Opcilloscope` instead of `opcilloscope`.

## Changes
- Replaced hardcoded `mv` command with a dynamic binary search using `find`
- Added case-insensitive matching (`-iname`) to locate the binary regardless of capitalization
- Implemented error handling to fail gracefully if the binary cannot be found in the archive
- Excluded `.pdb` debug files from the search to ensure only the actual executable is selected

## Implementation Details
- Uses `find` with `-maxdepth 1` to search only the top level of the temporary directory
- Filters for regular files (`-type f`) and excludes debug symbols (`-not -name '*.pdb'`)
- Uses `head -n 1` to select the first match if multiple candidates exist
- Provides clear error message if binary detection fails, improving debuggability for installation issues

https://claude.ai/code/session_01Aafxmwms5AMuRRMZPgFUzH