### PR TITLE
Increase scope view max samples from 200 to 2000

### DIFF
--- a/App/Views/ScopeView.cs
+++ b/App/Views/ScopeView.cs
@@ -26,7 +26,7 @@ public class ScopeView : View
     private class SeriesData
     {
         public MonitoredNode Node { get; init; } = null!;
-        public List<TimestampedSample> Samples { get; } = new(200);
+        public List<TimestampedSample> Samples { get; } = new(2000);
         public Terminal.Gui.Color LineColor { get; init; }
         public float VisibleMin { get; set; } = float.MaxValue;
         public float VisibleMax { get; set; } = float.MinValue;
@@ -34,7 +34,7 @@ public class ScopeView : View
 
     private readonly List<SeriesData> _series = new();
     private readonly object _lock = new();
-    private const int MaxSamples = 200;
+    private const int MaxSamples = 2000;
     private const double DefaultTimeWindowSeconds = 60.0;
 
     // Distinct colors for up to 5 series (using Terminal.Gui.Color)


### PR DESCRIPTION
This makes the dots denser on the oscilloscope view by allowing 10x more data points to be retained and displayed per signal series.

https://claude.ai/code/session_014B8o9YiaZEa9eeAvt4WamC