### PR TITLE
Change address space tree refresh shortcut from R to F5

### DIFF
--- a/App/Dialogs/HelpDialog.cs
+++ b/App/Dialogs/HelpDialog.cs
@@ -117,7 +117,7 @@ NAVIGATION
 ADDRESS SPACE
   Enter            Subscribe to selected node
   Space            Expand/collapse tree node
-  R                Refresh
+  F5               Refresh
 
 MONITORED VARIABLES
   Delete           Unsubscribe from item

--- a/App/MainWindow.cs
+++ b/App/MainWindow.cs
@@ -306,7 +306,7 @@ public class MainWindow : Toplevel, DefaultKeybindings.IKeybindingActions
                 new MenuBarItem("_View", new MenuItem[]
                 {
                     new MenuItem("_Scope", "S", LaunchScope),
-                    new MenuItem("_Refresh Tree", "R", RefreshTree),
+                    new MenuItem("_Refresh Tree", "F5", RefreshTree),
                     new MenuItem("_Clear Log", "", () => _logView.Clear()),
                     _themeToggleItem,
                     null!, // Separator

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,7 +459,7 @@ Automates release builds and publishing.
 | Key | Action |
 |-----|--------|
 | Enter | Subscribe to selected node |
-| R | Refresh address space tree |
+| F5 | Refresh address space tree |
 
 **Monitored Variables:**
 | Key | Action |


### PR DESCRIPTION
## Summary
Updated the keyboard shortcut for refreshing the address space tree from `R` to `F5` across the application, aligning with common UI conventions where F5 is the standard refresh key.

## Changes
- Updated the menu item shortcut in `MainWindow.cs` from "R" to "F5" for the "Refresh Tree" action
- Updated the help dialog in `HelpDialog.cs` to reflect the new F5 shortcut in the ADDRESS SPACE section
- Updated the documentation in `CLAUDE.md` to document the new F5 shortcut

## Details
This change makes the refresh functionality more discoverable and consistent with standard application behavior, where F5 is widely recognized as the refresh shortcut across most applications (browsers, file explorers, etc.). The R key is now available for other potential uses.

https://claude.ai/code/session_01MftpFpSAVmPdgHB6YYUhZp