### PR TITLE
Remove underscores from Recording menu item labels

### DIFF
--- a/App/MainWindow.cs
+++ b/App/MainWindow.cs
@@ -292,8 +292,8 @@ public class MainWindow : Toplevel, DefaultKeybindings.IKeybindingActions
                     new MenuItem("_Save Config", "", SaveConfig, shortcutKey: Key.S.WithCtrl),
                     new MenuItem("Save Config _As...", "", SaveConfigAs, shortcutKey: Key.S.WithCtrl.WithShift),
                     null!, // Separator
-                    new MenuItem("Start _Recording...", "", () => OnRecordRequested(), shortcutKey: Key.R.WithCtrl),
-                    new MenuItem("Sto_p Recording", "", () => OnStopRecordingRequested()),
+                    new MenuItem("Start Recording...", "", () => OnRecordRequested(), shortcutKey: Key.R.WithCtrl),
+                    new MenuItem("Stop Recording", "", () => OnStopRecordingRequested()),
                     null!, // Separator
                     new MenuItem("E_xit", "", () => RequestStop(), shortcutKey: Key.Q.WithCtrl)
                 }),


### PR DESCRIPTION
## Summary
Removed keyboard shortcut indicator underscores from the "Start Recording..." and "Stop Recording" menu items in the main menu bar.

## Changes
- Changed "Start _Recording..." to "Start Recording..." (removed underscore before 'R')
- Changed "Sto_p Recording" to "Stop Recording" (removed underscore before 'p')

## Details
These menu items already have keyboard shortcuts defined (Ctrl+R for Start Recording), so the underscore mnemonics are unnecessary. This change simplifies the menu labels and improves readability by removing the visual clutter of the underscore characters that were intended for keyboard navigation.

https://claude.ai/code/session_015YtxFN4aEH3XKnYpH3D1q2