### PR TITLE
Fix REC indicator width in MonitoredVariablesView

### DIFF
--- a/App/Views/MonitoredVariablesView.cs
+++ b/App/Views/MonitoredVariablesView.cs
@@ -194,6 +194,7 @@ public class MonitoredVariablesView : FrameView
             Text = "● REC",
             X = Pos.AnchorEnd(10),
             Y = 0,
+            Width = 10,
             Height = 1,
             ShadowStyle = ShadowStyle.None,
             ColorScheme = theme.ButtonColorScheme


### PR DESCRIPTION
## Summary
Added explicit width property to the REC (recording) indicator label to ensure proper layout and prevent text overflow or misalignment.

## Changes
- Set `Width = 10` on the REC indicator label in MonitoredVariablesView
  - The label was previously relying on implicit width calculation
  - Explicit width ensures consistent rendering and proper positioning with `Pos.AnchorEnd(10)`

## Details
The REC indicator is positioned at the end of the view using `Pos.AnchorEnd(10)`. By explicitly setting the width to 10 characters, we ensure the label has adequate space for its content ("● REC") and maintains proper alignment with other UI elements.

https://claude.ai/code/session_01WxUr7Pngy8HqxekRFdVRS1