### PR TITLE
Add padding to window title text

### DIFF
--- a/App/MainWindow.cs
+++ b/App/MainWindow.cs
@@ -100,7 +100,7 @@ public class MainWindow : Toplevel, DefaultKeybindings.IKeybindingActions
         ThemeManager.ThemeChanged += OnThemeChanged;
 
         // Set initial window title (status shown in status bar)
-        Title = "opcilloscope";
+        Title = " opcilloscope ";
 
         // Create menu bar
         _menuBar = CreateMenuBar();
@@ -755,7 +755,7 @@ public class MainWindow : Toplevel, DefaultKeybindings.IKeybindingActions
         var theme = ThemeManager.Current;
 
         // Update title (plain text)
-        Title = "opcilloscope";
+        Title = " opcilloscope ";
 
         // Update colored status label in status bar
         _connectionStatusLabel.Text = isConnected
@@ -1211,8 +1211,8 @@ License: MIT
         var unsavedMarker = _configService.HasUnsavedChanges ? "*" : "";
 
         Title = string.IsNullOrEmpty(_configService.CurrentFilePath) && !_configService.HasUnsavedChanges
-            ? "opcilloscope"
-            : $"opcilloscope - {configName}{unsavedMarker}";
+            ? " opcilloscope "
+            : $" opcilloscope - {configName}{unsavedMarker} ";
 
         SetNeedsLayout();
     }


### PR DESCRIPTION
## Summary
This PR adds whitespace padding around the application window title text in all locations where it's set.

## Changes
- Updated window title assignments to include leading and trailing spaces in three locations:
  - Initial title set in `MainWindow()` constructor
  - Title update in `UpdateConnectionStatus()` method
  - Title update in `UpdateWindowTitle()` method (both branches of the conditional)

## Details
The change modifies the window title from `"opcilloscope"` to `" opcilloscope "` (with spaces on both sides). This affects:
- The base title when no configuration file is loaded
- The title when displaying the current configuration file path
- The title formatting when unsaved changes are present

This appears to be a UI/UX adjustment to improve the visual presentation of the window title, possibly to add breathing room around the text in the window chrome.

https://claude.ai/code/session_01SKH7CXQhZrzkJG1werUj7T