### PR TITLE
Strip protocol prefix from initial endpoint in ConnectDialog

### DIFF
--- a/App/Dialogs/ConnectDialog.cs
+++ b/App/Dialogs/ConnectDialog.cs
@@ -59,7 +59,7 @@ public class ConnectDialog : Dialog
             X = 1 + ProtocolPrefix.Length,
             Y = 2,
             Width = Dim.Fill(1),
-            Text = initialEndpoint ?? string.Empty
+            Text = StripProtocolPrefix(initialEndpoint ?? string.Empty)
         };
 
         // Handle pasted addresses by stripping protocol prefixes


### PR DESCRIPTION
## Summary
Updated the ConnectDialog to strip protocol prefixes from the initial endpoint value when populating the text field, ensuring a consistent user experience.

## Changes
- Modified the `Text` property initialization of the endpoint input field to apply `StripProtocolPrefix()` to the `initialEndpoint` parameter
- This ensures that if an endpoint with a protocol prefix (e.g., "opc.tcp://") is passed to the dialog, it will be displayed without the prefix in the text field

## Details
The change aligns with the existing comment in the code that mentions "Handle pasted addresses by stripping protocol prefixes". By applying the same stripping logic to the initial endpoint, the dialog maintains consistency in how it handles protocol prefixes, whether they come from initialization parameters or user input.

https://claude.ai/code/session_011wkcEfSQAbss8f58535EGs