### PR TITLE
Add uninstall script and documentation for easy removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,26 @@ Then connect to any OPC UA server:
 opcilloscope
 ```
 
+### Uninstall
+
+**Linux / macOS:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/SquareWaveSystems/opcilloscope/main/uninstall.sh | bash
+```
+
+Or manually:
+```bash
+rm ~/.local/bin/opcilloscope
+rm -rf ~/.config/opcilloscope/  # optional: remove config files
+```
+
+**Windows (PowerShell):**
+```powershell
+Remove-Item "$env:LOCALAPPDATA\Opcilloscope" -Recurse -Force
+```
+
+If you installed to a custom directory (`OPCILLOSCOPE_INSTALL_DIR`), replace the paths above with your custom install location.
+
 ---
 
 ## Quickstart (Developer)

--- a/install.sh
+++ b/install.sh
@@ -101,6 +101,9 @@ install() {
         fi
 
         echo "Run 'opcilloscope' to start the application."
+        echo ""
+        echo "To uninstall later:"
+        echo "  curl -fsSL https://raw.githubusercontent.com/SquareWaveSystems/opcilloscope/main/uninstall.sh | bash"
     else
         error "Installation failed"
     fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -e
+
+# Opcilloscope uninstaller for Linux and macOS
+# Usage: curl -fsSL https://raw.githubusercontent.com/SquareWaveSystems/opcilloscope/main/uninstall.sh | bash
+
+INSTALL_DIR="${OPCILLOSCOPE_INSTALL_DIR:-$HOME/.local/bin}"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/opcilloscope"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+uninstall() {
+    echo ""
+    echo "  ╔═══════════════════════════════════╗"
+    echo "  ║    Opcilloscope Uninstaller       ║"
+    echo "  ║   Terminal OPC UA Client          ║"
+    echo "  ╚═══════════════════════════════════╝"
+    echo ""
+
+    local binary="${INSTALL_DIR}/opcilloscope"
+    local removed_something=false
+
+    # Remove binary
+    if [ -f "$binary" ]; then
+        rm "$binary"
+        info "Removed binary: ${binary}"
+        removed_something=true
+    else
+        warn "Binary not found at ${binary}"
+    fi
+
+    # Remove config directory
+    if [ -d "$CONFIG_DIR" ]; then
+        echo ""
+        echo -n "Remove configuration directory ${CONFIG_DIR}? [y/N] "
+        # When piped from curl, stdin is the script itself, so default to no
+        if [ -t 0 ]; then
+            read -r answer
+        else
+            answer="n"
+            echo "(skipped — run interactively to remove config files)"
+        fi
+
+        if [ "$answer" = "y" ] || [ "$answer" = "Y" ]; then
+            rm -rf "$CONFIG_DIR"
+            info "Removed config directory: ${CONFIG_DIR}"
+        else
+            info "Kept config directory: ${CONFIG_DIR}"
+        fi
+    fi
+
+    echo ""
+    if [ "$removed_something" = true ]; then
+        info "Opcilloscope has been uninstalled."
+    else
+        warn "Opcilloscope does not appear to be installed at ${INSTALL_DIR}."
+        echo ""
+        echo "If you installed to a custom directory, run:"
+        echo "  OPCILLOSCOPE_INSTALL_DIR=/your/path bash uninstall.sh"
+    fi
+}
+
+uninstall


### PR DESCRIPTION
## Summary
This PR adds comprehensive uninstall support for Opcilloscope, making it easy for users to cleanly remove the application from their systems.

## Changes
- **New `uninstall.sh` script**: Automated uninstaller for Linux and macOS that:
  - Removes the binary from the installation directory
  - Optionally removes configuration files (with user confirmation when run interactively)
  - Respects custom `OPCILLOSCOPE_INSTALL_DIR` environment variable
  - Provides helpful error messages and status updates with colored output
  - Handles both piped execution (via curl) and interactive execution gracefully

- **Updated `README.md`**: Added comprehensive uninstall instructions covering:
  - One-liner curl command for automated uninstall
  - Manual removal steps for Linux/macOS
  - Windows PowerShell removal instructions
  - Notes about custom installation directories

- **Updated `install.sh`**: Enhanced post-installation message to inform users about the uninstall option

## Implementation Details
- The uninstaller respects XDG Base Directory specification for config location (`$XDG_CONFIG_HOME` or `~/.config`)
- When piped from curl, config removal defaults to "no" to avoid accidental deletion
- Interactive execution allows users to choose whether to keep or remove config files
- Uses consistent color-coded output (green for info, yellow for warnings, red for errors) matching the installer style

https://claude.ai/code/session_01DNNCy5VrsqvKUNDcxvXJZX