### PR TITLE
Reorganize README: Move Features and Why sections before Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,37 @@ Browse, monitor, and subscribe to industrial automation data right from your ter
 
 ---
 
+## Why opcilloscope?
+
+Cause it was fun to build, but also...
+
+| Traditional OPC Clients | opcilloscope |
+|------------------------|--------------|
+| Heavy desktop apps with complex licensing | Single portable binary, MIT licensed |
+| Minutes to install | `curl | bash` and you're running |
+| Resource-hungry GUIs | ~50MB RAM, runs anywhere |
+| Windows-only | Windows, Linux, macOS (x64 & ARM) |
+| Click-heavy workflows | Keyboard driven, mouse support |
+
+- **Commissioning**: Quickly verify PLC tags are publishing correctly
+- **Troubleshooting**: Monitor live values during fault diagnosis
+- **Integration Testing**: Validate OPC UA server configurations
+- **Documentation**: Export snapshots for handover reports
+
+---
+
+## Features
+
+- **Browse** — Lazily explore the OPC UA address space. Expand only what you need.
+- **Monitor** — Subscribe to variables with `Enter`. Real-time updates via OPC UA subscriptions, not polling.
+- **Inspect** — Full node attributes: Description, DataType, AccessLevel, ValueRank.
+- **Scope** — Real-time multi-signal oscilloscope view (up to 5 signals).
+- **Record** — Export monitored values to CSV for analysis or documentation.
+- **Configure** — Save/load connection and subscription configs for recurring tasks.
+- **Themes** — Dark and light themes to match your environment.
+
+---
+
 ## Quickstart (User)
 
 **Linux / macOS:**
@@ -72,37 +103,6 @@ Run tests:
 ```bash
 dotnet test
 ```
-
----
-
-## Why opcilloscope?
-
-Cause it was fun to build, but also...
-
-| Traditional OPC Clients | opcilloscope |
-|------------------------|--------------|
-| Heavy desktop apps with complex licensing | Single portable binary, MIT licensed |
-| Minutes to install | `curl | bash` and you're running |
-| Resource-hungry GUIs | ~50MB RAM, runs anywhere |
-| Windows-only | Windows, Linux, macOS (x64 & ARM) |
-| Click-heavy workflows | Keyboard driven, mouse support |
-
-- **Commissioning**: Quickly verify PLC tags are publishing correctly
-- **Troubleshooting**: Monitor live values during fault diagnosis
-- **Integration Testing**: Validate OPC UA server configurations
-- **Documentation**: Export snapshots for handover reports
-
----
-
-## Features
-
-- **Browse** — Lazily explore the OPC UA address space. Expand only what you need.
-- **Monitor** — Subscribe to variables with `Enter`. Real-time updates via OPC UA subscriptions, not polling.
-- **Inspect** — Full node attributes: Description, DataType, AccessLevel, ValueRank.
-- **Scope** — Real-time multi-signal oscilloscope view (up to 5 signals).
-- **Record** — Export monitored values to CSV for analysis or documentation.
-- **Configure** — Save/load connection and subscription configs for recurring tasks.
-- **Themes** — Dark and light themes to match your environment.
 
 ---
 


### PR DESCRIPTION
## Summary
Reorganized the README.md structure to improve information hierarchy and user onboarding flow. The "Why opcilloscope?" and "Features" sections are now positioned immediately after the introduction and before the "Quickstart" section, making the value proposition and capabilities more prominent to new users.

## Changes
- Moved "Why opcilloscope?" section from after "Development" to after introduction
- Moved "Features" section to follow "Why opcilloscope?"
- Both sections now appear before "Quickstart (User)" for better discoverability
- No content changes—purely structural reorganization

## Rationale
This change improves the user journey by:
1. **Establishing value early** — Users see why they should use opcilloscope before diving into installation
2. **Clarifying capabilities** — Feature list is visible before quickstart, helping users understand what they can do
3. **Better information architecture** — Follows a logical flow: intro → motivation → features → getting started → development

The development and testing sections remain at the end where they're most relevant to contributors.

https://claude.ai/code/session_01MYYvn4MQv9sXFbt1U9dXCe