### PR TITLE
Remove redundant technology stack description from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 **A lightweight, cross-platform OPC UA client for the terminal heads.**
 
-Built with [.NET 10](https://dotnet.microsoft.com/download/dotnet/10.0), [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui), and the [OPC UA](https://opcfoundation.org/about/opc-technologies/opc-ua/) standard.
-
 Browse, monitor, and subscribe to industrial automation data right from your terminal. No bloated GUI, no complex setup, no license fees.
 
 [![.NET 10](https://img.shields.io/badge/.NET-10.0-purple)](https://dotnet.microsoft.com/download/dotnet/10.0)


### PR DESCRIPTION
## Summary
Removed the redundant line from the README that explicitly listed the technology stack (`.NET 10`, `Terminal.Gui`, and `OPC UA`), as this information is already conveyed through the badges and the project description itself.

## Changes
- Removed the technology stack description line from the README introduction
- Kept the informational badges that display the same technology information
- Maintained the core value proposition in the remaining description

## Rationale
The removed line was redundant since:
- The `.NET 10` badge already prominently displays the framework version
- The project description naturally implies the use of Terminal.Gui and OPC UA standards
- This simplifies the README while maintaining all essential information through badges and context

https://claude.ai/code/session_01QJ6xTUrzjr4KmQ2wWzPHen