### PR TITLE
Remove placeholder text from empty state views

### DIFF
--- a/App/Views/AddressSpaceView.cs
+++ b/App/Views/AddressSpaceView.cs
@@ -65,7 +65,7 @@ public class AddressSpaceView : FrameView
         {
             X = Pos.Center(),
             Y = Pos.Center(),
-            Text = "Connect to browse nodes",
+            Text = "",
             ColorScheme = new ColorScheme
             {
                 Normal = new Terminal.Gui.Attribute(theme.MutedText, theme.Background)

--- a/App/Views/MonitoredVariablesView.cs
+++ b/App/Views/MonitoredVariablesView.cs
@@ -160,7 +160,7 @@ public class MonitoredVariablesView : FrameView
         {
             X = Pos.Center(),
             Y = Pos.Center(),
-            Text = "Select nodes to monitor",
+            Text = "",
             ColorScheme = new ColorScheme
             {
                 Normal = new Attribute(theme.MutedText, theme.Background),

--- a/App/Views/NodeDetailsView.cs
+++ b/App/Views/NodeDetailsView.cs
@@ -48,7 +48,7 @@ public class NodeDetailsView : FrameView
             Y = 0,
             Width = Dim.Fill(9), // Leave space for Copy button
             Height = Dim.Fill(),
-            Text = "Select a node to view details",
+            Text = "",
             TextAlignment = Alignment.Start,
             ColorScheme = new ColorScheme
             {
@@ -71,7 +71,7 @@ public class NodeDetailsView : FrameView
             _copyButton.ColorScheme = theme.ButtonColorScheme;
 
             // When showing empty state, keep muted color
-            if (_detailsLabel.Text == "Select a node to view details" ||
+            if (_detailsLabel.Text == "" ||
                 _detailsLabel.Text == "Not connected")
             {
                 _detailsLabel.ColorScheme = new ColorScheme
@@ -108,7 +108,7 @@ public class NodeDetailsView : FrameView
             _currentNodeId = null;
             Application.Invoke(() =>
             {
-                _detailsLabel.Text = "Select a node to view details";
+                _detailsLabel.Text = "";
                 _copyButton.Enabled = false;
                 SetMutedColor();
             });


### PR DESCRIPTION
## Summary
This PR removes placeholder text messages from empty state views across the application, replacing them with empty strings. This change simplifies the UI by eliminating instructional text that appears when views are not yet populated with data.

## Changes
- **AddressSpaceView**: Removed "Connect to browse nodes" placeholder text
- **MonitoredVariablesView**: Removed "Select nodes to monitor" placeholder text
- **NodeDetailsView**: Removed "Select a node to view details" placeholder text and updated the corresponding conditional check in the theme change handler and node clearing logic

## Implementation Details
- All placeholder text has been replaced with empty strings (`Text = ""`)
- Updated the empty state check in `NodeDetailsView.OnThemeChanged()` to compare against the new empty string value
- The muted color styling for empty states is preserved and will still be applied when views are empty
- This change maintains the visual distinction of empty states through color theming while removing explicit instructional text

https://claude.ai/code/session_01EqFgWS8eJFEhzobLc45f47