### PR TITLE
Highlight main window title with bright accent color

### DIFF
--- a/App/MainWindow.cs
+++ b/App/MainWindow.cs
@@ -338,10 +338,10 @@ public class MainWindow : Toplevel, DefaultKeybindings.IKeybindingActions
         ColorScheme = theme.MainColorScheme;
         BorderStyle = theme.EmphasizedBorderStyle;
 
-        // Apply grey border color to main window border (consistent across terminals)
+        // Apply highlight title color to main window border so "opcilloscope" stands out
         if (Border != null)
         {
-            Border.ColorScheme = theme.BorderColorScheme;
+            Border.ColorScheme = theme.HighlightTitleBorderColorScheme;
         }
 
         // Apply styling to menu bar

--- a/App/Themes/AppTheme.cs
+++ b/App/Themes/AppTheme.cs
@@ -123,6 +123,7 @@ public abstract class AppTheme
     private ColorScheme? _frameColorScheme;
     private ColorScheme? _borderColorScheme;
     private ColorScheme? _focusedBorderColorScheme;
+    private ColorScheme? _highlightTitleBorderColorScheme;
 
     public virtual ColorScheme MainColorScheme => _mainColorScheme ??= new()
     {
@@ -179,6 +180,19 @@ public abstract class AppTheme
         Focus = BorderAttr,
         HotNormal = AccentAttr,  // Title text uses accent color
         HotFocus = AccentAttr,
+        Disabled = BorderAttr
+    };
+
+    /// <summary>
+    /// Color scheme for the main window border - uses bright accent for the title
+    /// so "opcilloscope" stands out prominently from sub-panel titles.
+    /// </summary>
+    public virtual ColorScheme HighlightTitleBorderColorScheme => _highlightTitleBorderColorScheme ??= new()
+    {
+        Normal = BorderAttr,
+        Focus = BorderAttr,
+        HotNormal = AccentBrightAttr,  // Title text uses bright accent to stand out
+        HotFocus = AccentBrightAttr,
         Disabled = BorderAttr
     };
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Cause it was fun to build, but also...
 
 | Traditional OPC Clients | opcilloscope |
 |------------------------|--------------|
-| Heavy desktop apps, potentially with licensing | Single portable binary, MIT licensed |
+| Heavy desktop apps | Single portable binary, MIT licensed |
 | Minutes to install | `curl | bash` and you're running |
 | Resource-hungry GUIs | ~50MB RAM, runs anywhere |
 | Windows-only | Windows, Linux, macOS (x64 & ARM) |


### PR DESCRIPTION
## Summary
Updated the main window border styling to use a bright accent color for the title text, making "opcilloscope" stand out more prominently from sub-panel titles. Also cleaned up marketing copy in the README.

## Changes
- **MainWindow.cs**: Changed border color scheme from `BorderColorScheme` to `HighlightTitleBorderColorScheme` to apply the new styling
- **AppTheme.cs**: Added new `HighlightTitleBorderColorScheme` color scheme that uses `AccentBrightAttr` for the title text (HotNormal/HotFocus states) while maintaining the standard border color for other elements
- **README.md**: Removed "potentially with licensing" qualifier from the Traditional OPC Clients comparison row for clarity

## Implementation Details
The new `HighlightTitleBorderColorScheme` leverages the existing `AccentBrightAttr` attribute to create visual distinction for the main window title. The HotNormal and HotFocus states are set to the bright accent color, which Terminal.Gui uses for rendering title text in borders, while Normal, Focus, and Disabled states remain as the standard `BorderAttr` for consistency with the window frame.

https://claude.ai/code/session_01KdpqvKyQ1i5Likg9md37DW