### PR TITLE
Remove test server instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,6 @@ dotnet build
 dotnet run
 ```
 
-Start the built-in test server (Counter, SineWave, RandomValue, writable nodes):
-```bash
-dotnet run --project Tests/Opcilloscope.TestServer
-# Starts at opc.tcp://localhost:4840
-```
-
 Run tests:
 ```bash
 dotnet test


### PR DESCRIPTION
## Summary
Removed outdated documentation for the built-in test server from the README.

## Changes
- Removed the "Start the built-in test server" section that referenced the Counter, SineWave, RandomValue, and writable nodes test server
- Removed the command `dotnet run --project Tests/Opcilloscope.TestServer` and its associated documentation
- Removed the note about the server starting at `opc.tcp://localhost:4840`

## Rationale
The test server instructions appear to be outdated or no longer relevant to the project setup. This cleanup simplifies the README and removes potentially confusing or broken documentation.

https://claude.ai/code/session_01Sb6hKfFB2coc4Pe59tPAuZ