### PR TITLE
Standardize application folder names to lowercase

### DIFF
--- a/Configuration/RecentFilesManager.cs
+++ b/Configuration/RecentFilesManager.cs
@@ -20,7 +20,7 @@ public class RecentFilesManager
     {
         _settingsPath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "Opcilloscope",
+            "opcilloscope",
             "recent-files.json"
         );
         Load();

--- a/OpcUa/OpcUaClientWrapper.cs
+++ b/OpcUa/OpcUaClientWrapper.cs
@@ -65,7 +65,7 @@ public class OpcUaClientWrapper : IDisposable
                     StoreType = CertificateStoreType.Directory,
                     StorePath = Path.Combine(
                         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                        "Opcilloscope", "pki", "own"),
+                        "opcilloscope", "pki", "own"),
                     SubjectName = "CN=Opcilloscope, O=Opcilloscope, DC=localhost"
                 },
                 TrustedIssuerCertificates = new CertificateTrustList
@@ -73,21 +73,21 @@ public class OpcUaClientWrapper : IDisposable
                     StoreType = CertificateStoreType.Directory,
                     StorePath = Path.Combine(
                         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                        "Opcilloscope", "pki", "issuer")
+                        "opcilloscope", "pki", "issuer")
                 },
                 TrustedPeerCertificates = new CertificateTrustList
                 {
                     StoreType = CertificateStoreType.Directory,
                     StorePath = Path.Combine(
                         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                        "Opcilloscope", "pki", "trusted")
+                        "opcilloscope", "pki", "trusted")
                 },
                 RejectedCertificateStore = new CertificateTrustList
                 {
                     StoreType = CertificateStoreType.Directory,
                     StorePath = Path.Combine(
                         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                        "Opcilloscope", "pki", "rejected")
+                        "opcilloscope", "pki", "rejected")
                 },
                 AutoAcceptUntrustedCertificates = true,
                 AddAppCertToTrustedStore = false

--- a/README.md
+++ b/README.md
@@ -85,12 +85,14 @@ curl -fsSL https://raw.githubusercontent.com/SquareWaveSystems/opcilloscope/main
 Or manually:
 ```bash
 rm ~/.local/bin/opcilloscope
-rm -rf ~/.config/opcilloscope/  # optional: remove config files
+rm -rf ~/.config/opcilloscope/       # optional: remove config files
+rm -rf ~/.local/share/opcilloscope/  # optional: remove OPC UA certificates
 ```
 
 **Windows (PowerShell):**
 ```powershell
-Remove-Item "$env:LOCALAPPDATA\Opcilloscope" -Recurse -Force
+Remove-Item "$env:LOCALAPPDATA\opcilloscope" -Recurse -Force   # OPC UA certificates
+Remove-Item "$env:APPDATA\opcilloscope" -Recurse -Force        # config files
 ```
 
 If you installed to a custom directory (`OPCILLOSCOPE_INSTALL_DIR`), replace the paths above with your custom install location.

--- a/Tests/Opcilloscope.TestServer/TestServer.cs
+++ b/Tests/Opcilloscope.TestServer/TestServer.cs
@@ -70,7 +70,7 @@ public class TestServer : IAsyncDisposable, IDisposable
     {
         var pkiPath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "Opcilloscope",
+            "opcilloscope",
             "TestServer",
             "pki");
 


### PR DESCRIPTION
## Summary
This PR standardizes all application folder names from "Opcilloscope" to "opcilloscope" (lowercase) across the codebase for consistency with Linux/Unix naming conventions and improved cross-platform compatibility.

## Key Changes
- Updated RecentFilesManager to use lowercase "opcilloscope" folder in ApplicationData
- Updated OpcUaClientWrapper certificate store paths to use lowercase "opcilloscope" folder in LocalApplicationData
- Updated TestServer PKI path to use lowercase "opcilloscope" folder
- Updated README.md uninstall instructions to reflect the correct lowercase folder names and clarify separate locations for OPC UA certificates and config files on both Linux and Windows

## Implementation Details
- All file system paths now consistently use lowercase "opcilloscope" directory names
- Windows paths now correctly reference:
  - `%LOCALAPPDATA%\opcilloscope` for OPC UA certificates (PKI)
  - `%APPDATA%\opcilloscope` for configuration files
- Linux paths remain consistent with `~/.local/share/opcilloscope` and `~/.config/opcilloscope`
- This change improves consistency with standard Linux naming conventions and makes the application more portable across different operating systems

https://claude.ai/code/session_01GUHbHj3z8agQQx3LJMrpvV