### PR TITLE
Enable invariant globalization mode to remove ICU dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install ICU libraries
-        # .NET runtime requires libicu for globalization (may be missing on minimal images)
-        run: sudo apt-get update && sudo apt-get install -y libicu-dev
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:

--- a/Opcilloscope.csproj
+++ b/Opcilloscope.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Opcilloscope</RootNamespace>
     <AssemblyName>opcilloscope</AssemblyName>
+    <InvariantGlobalization>true</InvariantGlobalization>
 
     <!-- Package metadata (Version is driven by MinVer from Git tags) -->
     <Authors>Brett Kinny</Authors>

--- a/README.md
+++ b/README.md
@@ -75,13 +75,6 @@ irm https://raw.githubusercontent.com/SquareWaveSystems/opcilloscope/main/instal
 
 Or grab a binary from [GitHub Releases](https://github.com/SquareWaveSystems/opcilloscope/releases).
 
-**Linux dependency:** opcilloscope requires ICU libraries at runtime for globalization support. On Debian/Ubuntu:
-```bash
-sudo apt install libicu72    # Debian 13 / Ubuntu 24.04+
-# or: sudo apt install libicu-dev   # installs any available version
-```
-On Fedora/RHEL: `sudo dnf install libicu`
-
 Then to run:
 ```bash
 opcilloscope

--- a/Tests/Opcilloscope.TestServer/Opcilloscope.TestServer.csproj
+++ b/Tests/Opcilloscope.TestServer/Opcilloscope.TestServer.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Opcilloscope.TestServer</RootNamespace>
     <AssemblyName>Opcilloscope.TestServer</AssemblyName>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Opcilloscope.Tests/Opcilloscope.Tests.csproj
+++ b/Tests/Opcilloscope.Tests/Opcilloscope.Tests.csproj
@@ -7,6 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
This PR removes the runtime dependency on ICU (International Components for Unicode) libraries by enabling .NET's invariant globalization mode. This simplifies deployment and eliminates the need for platform-specific library installation steps.

## Key Changes
- Added `<InvariantGlobalization>true</InvariantGlobalization>` to all three project files:
  - `Opcilloscope.csproj` (main application)
  - `Opcilloscope.TestServer.csproj` (test server)
  - `Opcilloscope.Tests.csproj` (test project)
- Removed ICU library installation instructions from README.md (Debian/Ubuntu and Fedora/RHEL specific steps)
- Removed ICU library installation step from CI/CD pipeline (`.github/workflows/ci.yml`)

## Implementation Details
By enabling invariant globalization mode, the application will use the invariant culture for all globalization operations rather than relying on system-provided ICU libraries. This is a common approach for applications that don't require locale-specific formatting or collation, reducing deployment complexity and improving portability across different Linux distributions.

https://claude.ai/code/session_01FJHaXGtwgSBicEuLMHpvVg