### PR TITLE
Fix CSV recording data race, shutdown queue drop, and stale-queue contamination

### DIFF
--- a/Tests/Opcilloscope.Tests/Utilities/CsvRecordingManagerTests.cs
+++ b/Tests/Opcilloscope.Tests/Utilities/CsvRecordingManagerTests.cs
@@ -447,4 +447,91 @@ public class CsvRecordingManagerTests : IDisposable
         // Verify it's in ISO 8601 format with T
         Assert.Contains("T", timestamp);
     }
+
+    [Fact]
+    public void RecordValue_SnapshotsValueAtEnqueueTime_NotLiveReference()
+    {
+        // Arrange
+        var filePath = Path.Combine(_testDirectory, "test.csv");
+        _manager.StartRecording(filePath);
+        var node = new MonitoredNode
+        {
+            DisplayName = "SnapNode",
+            NodeId = new NodeId(1234),
+            Value = "original",
+            StatusCode = 0
+        };
+
+        // Act - enqueue, then mutate the live node in place (as the OPC thread would).
+        // The snapshot is captured synchronously inside RecordValue, so the writer
+        // must serialize "original", never the later "mutated" state.
+        _manager.RecordValue(node);
+        node.Value = "mutated";
+        node.StatusCode = 0x80020000;
+        Thread.Sleep(200); // Give the background writer time to process
+        _manager.StopRecording();
+
+        // Assert
+        var content = File.ReadAllText(filePath);
+        Assert.Contains("original", content);
+        Assert.DoesNotContain("mutated", content);
+        // Status was Good at enqueue time; the later Bad mutation must not appear.
+        Assert.DoesNotContain("Bad", content);
+    }
+
+    [Fact]
+    public void StopRecording_FlushesQueuedRecordsBeforeClosing()
+    {
+        // Arrange
+        var filePath = Path.Combine(_testDirectory, "test.csv");
+        _manager.StartRecording(filePath);
+        const int count = 50;
+        for (int i = 0; i < count; i++)
+        {
+            _manager.RecordValue(new MonitoredNode
+            {
+                DisplayName = $"Node{i}",
+                NodeId = new NodeId((uint)i),
+                Value = $"v{i}"
+            });
+        }
+
+        // Act - stop immediately without waiting. The in-flight tail must still be
+        // flushed (StopRecording waits for the writer, which drains the queue).
+        _manager.StopRecording();
+
+        // Assert
+        Assert.Equal(count, _manager.RecordCount);
+        var lines = File.ReadAllLines(filePath);
+        Assert.Equal(count + 1, lines.Length); // header + all records
+    }
+
+    [Fact]
+    public void StartRecording_ClearsStaleQueueFromPreviousSession()
+    {
+        // Arrange - first session leaves a record queued but is stopped.
+        var filePath1 = Path.Combine(_testDirectory, "session1.csv");
+        _manager.StartRecording(filePath1);
+        _manager.StopRecording();
+
+        // Enqueue while not recording (dropped at RecordValue, but be defensive).
+        _manager.RecordValue(new MonitoredNode
+        {
+            DisplayName = "StaleNode",
+            NodeId = new NodeId(999),
+            Value = "stale"
+        });
+
+        // Act - a fresh session must not pick up anything from before.
+        var filePath2 = Path.Combine(_testDirectory, "session2.csv");
+        _manager.StartRecording(filePath2);
+        Thread.Sleep(100);
+        _manager.StopRecording();
+
+        // Assert
+        var content = File.ReadAllText(filePath2);
+        Assert.DoesNotContain("StaleNode", content);
+        Assert.DoesNotContain("stale", content);
+        Assert.Equal(0, _manager.RecordCount);
+    }
 }

--- a/Utilities/CsvRecordingManager.cs
+++ b/Utilities/CsvRecordingManager.cs
@@ -174,6 +174,18 @@ public class CsvRecordingManager : IDisposable
         return filename;
     }
 
+    /// <summary>
+    /// Immutable snapshot of a monitored value captured at enqueue time.
+    /// Decouples the background writer from the live <see cref="MonitoredNode"/>,
+    /// which the OPC notification thread mutates in place.
+    /// </summary>
+    private readonly record struct RecordSnapshot(
+        DateTime? Timestamp,
+        string DisplayName,
+        string NodeId,
+        string Value,
+        string Status);
+
     private readonly Logger _logger;
     private StreamWriter? _writer;
     private string? _filePath;
@@ -181,7 +193,7 @@ public class CsvRecordingManager : IDisposable
     private readonly object _lock = new();
     private DateTime _recordingStartTime;
     private long _recordCount;
-    private readonly ConcurrentQueue<MonitoredNode> _recordQueue = new();
+    private readonly ConcurrentQueue<RecordSnapshot> _recordQueue = new();
     private readonly SemaphoreSlim _queueSemaphore = new(0);
     private Task? _writeTask;
     private CancellationTokenSource? _cancellationTokenSource;
@@ -239,6 +251,10 @@ public class CsvRecordingManager : IDisposable
                 _writer.WriteLine("Timestamp,DisplayName,NodeId,Value,Status");
                 _writer.Flush();
 
+                // Discard any stale snapshots left over from a previous session
+                // so they cannot cross-contaminate the new recording.
+                while (_recordQueue.TryDequeue(out _)) { }
+
                 _isRecording = true;
                 _recordingStartTime = DateTime.Now;
                 _recordCount = 0;
@@ -248,8 +264,6 @@ public class CsvRecordingManager : IDisposable
                 _writeTask = Task.Run(() => WriteQueuedRecordsAsync(_cancellationTokenSource.Token));
 
                 _logger.Info($"Started recording to {_filePath}");
-                RecordingStateChanged?.Invoke(true);
-                return true;
             }
             catch (Exception ex)
             {
@@ -260,6 +274,11 @@ public class CsvRecordingManager : IDisposable
                 return false;
             }
         }
+
+        // Raise the event after releasing the lock to avoid invoking
+        // subscriber callbacks while holding it.
+        RecordingStateChanged?.Invoke(true);
+        return true;
     }
 
     /// <summary>
@@ -338,9 +357,12 @@ public class CsvRecordingManager : IDisposable
                 ctsToDispose?.Dispose();
                 _cancellationTokenSource = null;
                 _writeTask = null;
-                RecordingStateChanged?.Invoke(false);
             }
         }
+
+        // Raise the event after releasing the lock to avoid invoking
+        // subscriber callbacks while holding it.
+        RecordingStateChanged?.Invoke(false);
     }
 
     /// <summary>
@@ -354,8 +376,19 @@ public class CsvRecordingManager : IDisposable
             return;
         }
 
-        // Queue the item for background writing (non-blocking)
-        _recordQueue.Enqueue(item);
+        // Capture an immutable snapshot at enqueue time. The OPC notification
+        // thread mutates the live MonitoredNode in place, so queuing the
+        // reference would let the writer serialize a newer state than was
+        // sampled (duplicated/skipped rows under load).
+        var snapshot = new RecordSnapshot(
+            item.Timestamp,
+            item.DisplayName,
+            item.NodeId.ToString(),
+            item.Value,
+            item.StatusString);
+
+        // Queue the snapshot for background writing (non-blocking)
+        _recordQueue.Enqueue(snapshot);
         _queueSemaphore.Release();
     }
 
@@ -417,11 +450,14 @@ public class CsvRecordingManager : IDisposable
     /// <summary>
     /// Write a single record to the CSV file.
     /// </summary>
-    private void WriteRecord(MonitoredNode item)
+    private void WriteRecord(RecordSnapshot item)
     {
         lock (_lock)
         {
-            if (_writer == null || !_isRecording)
+            // Only the writer guard here: _isRecording is cleared before the
+            // shutdown drain, so checking it would discard the in-flight tail
+            // (flush-on-stop and re-queue-on-cancel records).
+            if (_writer == null)
             {
                 return;
             }
@@ -434,9 +470,9 @@ public class CsvRecordingManager : IDisposable
 
                 // Escape values for CSV (handle quotes and commas)
                 var displayName = EscapeCsvField(item.DisplayName);
-                var nodeId = EscapeCsvField(item.NodeId.ToString());
+                var nodeId = EscapeCsvField(item.NodeId);
                 var value = EscapeCsvField(item.Value);
-                var status = EscapeCsvField(item.StatusString);
+                var status = EscapeCsvField(item.Status);
 
                 _writer.WriteLine($"{timestamp},{displayName},{nodeId},{value},{status}");
 


### PR DESCRIPTION
## Summary
- Enqueue an immutable `RecordSnapshot` record (Timestamp, DisplayName, NodeId, Value, Status) captured synchronously in `RecordValue`, instead of the live `MonitoredNode` reference that the OPC notification thread mutates in place. The background writer now serializes the sampled state, eliminating duplicated/skipped rows under load.
- Drop the `!_isRecording` clause from the `WriteRecord` guard (keep the `_writer == null` guard). Since `_isRecording` is cleared before the shutdown drain, the old guard made flush-on-stop and re-queue-on-cancel dead code, silently discarding the in-flight tail.
- Drain `_recordQueue` when recording starts so values left over from a previous session cannot cross-contaminate a new recording.
- Raise `RecordingStateChanged` after releasing `_lock` in both `StartRecording` and `StopRecording`.
- Add unit tests (no OPC server required): snapshot-not-live-reference, flush-on-stop, and stale-queue clearing.

## Test plan
- [x] `dotnet build Opcilloscope.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~CsvRecordingManagerTests"` — 23 passed (20 existing + 3 new)
- [ ] Full suite incl. integration tests — runs in CI

---
Part of the v1 release-readiness punch list (`docs/V1-REVIEW.md`). 🤖 Generated by the `v1-fixes` workflow.
