### PR TITLE
Fix culture-sensitive value parsing and IPv6 identifier handling

### DIFF
--- a/Tests/Opcilloscope.Tests/Utilities/ConnectionIdentifierTests.cs
+++ b/Tests/Opcilloscope.Tests/Utilities/ConnectionIdentifierTests.cs
@@ -163,6 +163,75 @@ public class ConnectionIdentifierTests
     }
 
     [Fact]
+    public void ExtractHostPort_WithBracketedIpv6AndPort_SeparatesHostAndPort()
+    {
+        // Act
+        var result = ConnectionIdentifier.ExtractHostPort("opc.tcp://[2001:db8::1]:50000");
+
+        // Assert - port must be split off cleanly and not merged into the host
+        Assert.EndsWith("-50000", result);
+        Assert.Contains("-", result);
+        Assert.DoesNotContain("[", result);
+        Assert.DoesNotContain("]", result);
+        Assert.DoesNotContain(":", result);
+    }
+
+    [Fact]
+    public void ExtractHostPort_WithBracketedIpv6Loopback_DoesNotMangleAddress()
+    {
+        // The bug case: LastIndexOf(':') split "[::1]:4840" inside the address.
+        // Act
+        var result = ConnectionIdentifier.ExtractHostPort("opc.tcp://[::1]:4840");
+
+        // Assert
+        Assert.EndsWith("-4840", result);
+        Assert.DoesNotContain("[", result);
+        Assert.DoesNotContain("]", result);
+        Assert.DoesNotContain(":", result);
+    }
+
+    [Fact]
+    public void ExtractHostPort_WithBracketedIpv6NoPort_ReturnsHostOnly()
+    {
+        // Act
+        var result = ConnectionIdentifier.ExtractHostPort("opc.tcp://[::1]");
+
+        // Assert - no port, so no trailing "-port"
+        Assert.DoesNotContain("[", result);
+        Assert.DoesNotContain("]", result);
+        Assert.DoesNotContain(":", result);
+        Assert.DoesNotMatch(@"-\d+$", result);
+    }
+
+    [Fact]
+    public void ExtractHostPort_WithBracketedIpv6AndPath_IgnoresPathAndKeepsPort()
+    {
+        // Act
+        var result = ConnectionIdentifier.ExtractHostPort("opc.tcp://[2001:db8::1]:50000/UA/Server");
+
+        // Assert
+        Assert.EndsWith("-50000", result);
+        Assert.DoesNotContain("UA", result);
+        Assert.DoesNotContain("Server", result);
+    }
+
+    [Fact]
+    public void Generate_WithBracketedIpv6_ProducesCleanIdentifier()
+    {
+        // Arrange
+        var timestamp = new DateTime(2026, 1, 7, 12, 34, 0);
+
+        // Act
+        var result = ConnectionIdentifier.Generate("opc.tcp://[::1]:4840", timestamp);
+
+        // Assert - identifier remains filename-safe and ends with the timestamp
+        Assert.EndsWith("_20260107_1234", result);
+        Assert.DoesNotContain("[", result);
+        Assert.DoesNotContain("]", result);
+        Assert.DoesNotContain(":", result);
+    }
+
+    [Fact]
     public void LimitLength_WithShortIdentifier_ReturnsUnchanged()
     {
         // Act

--- a/Tests/Opcilloscope.Tests/Utilities/OpcValueConverterTests.cs
+++ b/Tests/Opcilloscope.Tests/Utilities/OpcValueConverterTests.cs
@@ -274,6 +274,68 @@ public class OpcValueConverterTests
             $"Expected error about 'out of range' or 'valid decimal', got: {error}");
     }
 
+    [Theory]
+    [InlineData("3,14")]
+    [InlineData("1,000")]
+    [InlineData("1.234,56")]
+    public void TryConvert_Float_CommaSeparator_ReturnsFalse(string input)
+    {
+        // Regression: under invariant parsing a ',' must never be treated as a
+        // decimal or thousands separator (e.g. "3,14" silently becoming 314).
+        // Act
+        var (success, value, error) = OpcValueConverter.TryConvert(input, BuiltInType.Float);
+
+        // Assert
+        Assert.False(success);
+        Assert.Null(value);
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData("3,14")]
+    [InlineData("1,000")]
+    [InlineData("1.234,56")]
+    public void TryConvert_Double_CommaSeparator_ReturnsFalse(string input)
+    {
+        // Regression: under invariant parsing a ',' must never be treated as a
+        // decimal or thousands separator (e.g. "3,14" silently becoming 314).
+        // Act
+        var (success, value, error) = OpcValueConverter.TryConvert(input, BuiltInType.Double);
+
+        // Assert
+        Assert.False(success);
+        Assert.Null(value);
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData("3.14", 3.14f)]
+    [InlineData("1000", 1000f)]
+    public void TryConvert_Float_DotDecimal_AlwaysInvariant(string input, float expected)
+    {
+        // Act
+        var (success, value, error) = OpcValueConverter.TryConvert(input, BuiltInType.Float);
+
+        // Assert
+        Assert.True(success);
+        Assert.Equal(expected, (float)value!);
+        Assert.Null(error);
+    }
+
+    [Theory]
+    [InlineData("3.14", 3.14)]
+    [InlineData("1000", 1000.0)]
+    public void TryConvert_Double_DotDecimal_AlwaysInvariant(string input, double expected)
+    {
+        // Act
+        var (success, value, error) = OpcValueConverter.TryConvert(input, BuiltInType.Double);
+
+        // Assert
+        Assert.True(success);
+        Assert.Equal(expected, (double)value!);
+        Assert.Null(error);
+    }
+
     #endregion
 
     #region String Tests
@@ -323,6 +385,33 @@ public class OpcValueConverterTests
         Assert.True(success);
         Assert.IsType<DateTime>(value);
         Assert.Null(error);
+    }
+
+    [Fact]
+    public void TryConvert_DateTime_NormalizesToUtcKind()
+    {
+        // Act
+        var (success, value, error) = OpcValueConverter.TryConvert("2026-01-06 12:00:00", BuiltInType.DateTime);
+
+        // Assert
+        Assert.True(success);
+        Assert.Null(error);
+        var dt = Assert.IsType<DateTime>(value);
+        Assert.Equal(DateTimeKind.Utc, dt.Kind);
+    }
+
+    [Fact]
+    public void TryConvert_DateTime_WithOffset_ConvertsToUtc()
+    {
+        // Act - 12:00 at +02:00 is 10:00 UTC
+        var (success, value, error) = OpcValueConverter.TryConvert("2026-01-06T12:00:00+02:00", BuiltInType.DateTime);
+
+        // Assert
+        Assert.True(success);
+        Assert.Null(error);
+        var dt = Assert.IsType<DateTime>(value);
+        Assert.Equal(DateTimeKind.Utc, dt.Kind);
+        Assert.Equal(new DateTime(2026, 1, 6, 10, 0, 0, DateTimeKind.Utc), dt);
     }
 
     [Theory]

--- a/Utilities/ConnectionIdentifier.cs
+++ b/Utilities/ConnectionIdentifier.cs
@@ -36,32 +36,70 @@ public static class ConnectionIdentifier
         if (string.IsNullOrEmpty(endpointUrl))
             return "unknown";
 
-        var url = endpointUrl;
-
         // Remove protocol prefix
-        url = RemoveProtocolPrefix(url);
+        var url = RemoveProtocolPrefix(endpointUrl);
 
-        // Extract host and port before any path
-        var pathIndex = url.IndexOf('/');
-        if (pathIndex >= 0)
-            url = url.Substring(0, pathIndex);
+        string host;
+        string? port = null;
 
-        // Parse host and port
-        var lastColonIndex = url.LastIndexOf(':');
-        if (lastColonIndex > 0)
+        if (url.StartsWith('['))
         {
-            var host = url.Substring(0, lastColonIndex);
-            var port = url.Substring(lastColonIndex + 1);
+            // Bracketed IPv6 literal, e.g. "[::1]:4840" or "[2001:db8::1]/path".
+            // The colons inside the brackets are part of the address, not a port
+            // separator, so split on the closing bracket first.
+            var closeBracket = url.IndexOf(']');
+            if (closeBracket > 0)
+            {
+                host = url.Substring(1, closeBracket - 1);
 
-            // Sanitize host (replace dots are ok, but sanitize other chars)
-            host = SanitizeComponent(host);
+                var rest = url.Substring(closeBracket + 1);
+
+                // Strip any path after the host/port.
+                var restPathIndex = rest.IndexOf('/');
+                if (restPathIndex >= 0)
+                    rest = rest.Substring(0, restPathIndex);
+
+                // Whatever remains, if anything, is ":port".
+                if (rest.StartsWith(':') && rest.Length > 1)
+                    port = rest.Substring(1);
+            }
+            else
+            {
+                // Malformed (no closing bracket) - fall back to the whole string.
+                host = url;
+            }
+        }
+        else
+        {
+            // Extract host and port before any path
+            var pathIndex = url.IndexOf('/');
+            if (pathIndex >= 0)
+                url = url.Substring(0, pathIndex);
+
+            // Parse host and port
+            var lastColonIndex = url.LastIndexOf(':');
+            if (lastColonIndex > 0)
+            {
+                host = url.Substring(0, lastColonIndex);
+                port = url.Substring(lastColonIndex + 1);
+            }
+            else
+            {
+                host = url;
+            }
+        }
+
+        // Sanitize host (replace dots are ok, but sanitize other chars)
+        host = SanitizeComponent(host);
+
+        if (!string.IsNullOrEmpty(port))
+        {
             port = SanitizeComponent(port);
-
             return $"{host}-{port}";
         }
 
         // No port specified, just sanitize the host
-        return SanitizeComponent(url);
+        return host;
     }
 
     /// <summary>

--- a/Utilities/OpcValueConverter.cs
+++ b/Utilities/OpcValueConverter.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Opc.Ua;
 
 namespace Opcilloscope.Utilities;
@@ -71,13 +72,15 @@ public static class OpcValueConverter
     /// Parses a Float value. Rejects NaN and Infinity values for safety.
     /// </summary>
     /// <remarks>
-    /// Note: float.TryParse can successfully parse "NaN", "Infinity", and "-Infinity" 
-    /// into their respective special floating-point values. These are explicitly rejected 
+    /// Note: float.TryParse can successfully parse "NaN", "Infinity", and "-Infinity"
+    /// into their respective special floating-point values. These are explicitly rejected
     /// to prevent unintended writes of special values to OPC UA nodes.
+    /// Parsing uses the invariant culture so that ',' is never treated as a decimal or
+    /// thousands separator (e.g. "3,14" must not silently become 314).
     /// </remarks>
     private static (bool, object?, string?) TryParseFloat(string input)
     {
-        if (float.TryParse(input.Trim(), out var result))
+        if (float.TryParse(input.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var result))
         {
             if (float.IsNaN(result) || float.IsInfinity(result))
             {
@@ -92,13 +95,15 @@ public static class OpcValueConverter
     /// Parses a Double value. Rejects NaN and Infinity values for safety.
     /// </summary>
     /// <remarks>
-    /// Note: double.TryParse can successfully parse "NaN", "Infinity", and "-Infinity" 
-    /// into their respective special floating-point values. These are explicitly rejected 
+    /// Note: double.TryParse can successfully parse "NaN", "Infinity", and "-Infinity"
+    /// into their respective special floating-point values. These are explicitly rejected
     /// to prevent unintended writes of special values to OPC UA nodes.
+    /// Parsing uses the invariant culture so that ',' is never treated as a decimal or
+    /// thousands separator (e.g. "3,14" must not silently become 314).
     /// </remarks>
     private static (bool, object?, string?) TryParseDouble(string input)
     {
-        if (double.TryParse(input.Trim(), out var result))
+        if (double.TryParse(input.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var result))
         {
             if (double.IsNaN(result) || double.IsInfinity(result))
             {
@@ -109,9 +114,19 @@ public static class OpcValueConverter
         return (false, null, "Enter a valid decimal number");
     }
 
+    /// <summary>
+    /// Parses a DateTime value and normalizes it to UTC so the written value has a
+    /// well-defined kind. Inputs without an explicit offset are assumed to be UTC;
+    /// inputs with an offset are converted to UTC. This avoids writing an ambiguous
+    /// Kind=Unspecified value to an OPC UA node.
+    /// </summary>
     private static (bool, object?, string?) TryParseDateTime(string input)
     {
-        if (DateTime.TryParse(input.Trim(), out var result))
+        if (DateTime.TryParse(
+                input.Trim(),
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var result))
         {
             return (true, result, null);
         }


### PR DESCRIPTION
## Summary
- Parse `Float`/`Double` values with `NumberStyles.Float` and `CultureInfo.InvariantCulture` so a `,` is never interpreted as a decimal or thousands separator. Previously inputs like `3,14` or `1,000` could silently parse to `314`/`1000` and write a wrong value to an industrial node. Integer parses were audited and left unchanged — the default `NumberStyles.Integer` rejects commas and decimals.
- Normalize parsed `DateTime` values to UTC using `DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal`, so written values always have a well-defined `Kind=Utc` instead of an ambiguous `Unspecified` kind. Inputs with an explicit offset are converted to UTC.
- Handle bracketed IPv6 literals (e.g. `[::1]:4840`, `[2001:db8::1]:50000/path`) in `ConnectionIdentifier.ExtractHostPort`. The previous `LastIndexOf(':')` logic split inside the address, mangling host and port together when generating filenames/identifiers. Host/port are now split on the closing bracket, with path stripping preserved.
- Added focused, server-free unit tests for the comma-separator regression, DateTime UTC normalization, and IPv6 parsing.

## Test plan
- [x] `dotnet build Opcilloscope.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test --filter "...OpcValueConverterTests|...ConnectionIdentifierTests"` — 136 passed, 0 failed
- [ ] Full suite (incl. integration) runs in CI

---
Part of the v1 release-readiness punch list (`docs/V1-REVIEW.md`). 🤖 Generated by the `v1-fixes` workflow.
