### PR TITLE
Harden SubscriptionManager: dedup race, handler leaks, dead field

### DIFF
--- a/OpcUa/Models/MonitoredNode.cs
+++ b/OpcUa/Models/MonitoredNode.cs
@@ -8,7 +8,6 @@ namespace Opcilloscope.OpcUa.Models;
 public class MonitoredNode
 {
     public uint ClientHandle { get; init; }
-    public uint MonitoredItemId { get; set; }
     public NodeId NodeId { get; init; } = ObjectIds.RootFolder;
     public string DisplayName { get; init; } = string.Empty;
     public string Value { get; set; } = string.Empty;

--- a/OpcUa/SubscriptionManager.cs
+++ b/OpcUa/SubscriptionManager.cs
@@ -140,6 +140,7 @@ public class SubscriptionManager : IDisposable, IAsyncDisposable
             if (ServiceResult.IsBad(monitoredItem.Status.Error))
             {
                 _logger.Error($"Failed to create monitored item for {displayName}: {monitoredItem.Status.Error}");
+                monitoredItem.Notification -= MonitoredItem_Notification;
                 _subscription.RemoveItem(monitoredItem);
                 return null;
             }
@@ -148,18 +149,33 @@ public class SubscriptionManager : IDisposable, IAsyncDisposable
             var variable = new MonitoredNode
             {
                 ClientHandle = clientHandle,
-                MonitoredItemId = monitoredItem.ClientHandle,
                 NodeId = nodeId,
                 DisplayName = displayName,
                 Value = "(pending)",
                 StatusCode = 0 // Good
             };
 
+            // Re-check membership after the await to close the TOCTOU window: a concurrent
+            // AddNodeAsync may have added the same node while we awaited ApplyChangesAsync.
+            bool duplicate;
             lock (_lock)
             {
-                _monitoredVariables[clientHandle] = variable;
-                _opcMonitoredItems[clientHandle] = monitoredItem;
-                _opcHandleToClientHandle[monitoredItem.ClientHandle] = clientHandle;
+                duplicate = _monitoredVariables.Values.Any(m => m.NodeId.EqualsNodeId(nodeId));
+                if (!duplicate)
+                {
+                    _monitoredVariables[clientHandle] = variable;
+                    _opcMonitoredItems[clientHandle] = monitoredItem;
+                    _opcHandleToClientHandle[monitoredItem.ClientHandle] = clientHandle;
+                }
+            }
+
+            if (duplicate)
+            {
+                _logger.Warning($"Node {displayName} is already being monitored");
+                monitoredItem.Notification -= MonitoredItem_Notification;
+                _subscription.RemoveItem(monitoredItem);
+                await _subscription.ApplyChangesAsync();
+                return null;
             }
 
             _logger.Info($"Subscribed to {displayName}");
@@ -625,14 +641,21 @@ public class SubscriptionManager : IDisposable, IAsyncDisposable
     /// </summary>
     public void MarkAllAsStale()
     {
+        List<MonitoredNode> staleVariables;
         lock (_lock)
         {
-            foreach (var variable in _monitoredVariables.Values)
+            staleVariables = _monitoredVariables.Values.ToList();
+            foreach (var variable in staleVariables)
             {
                 variable.Value = "(reconnecting...)";
                 variable.StatusCode = StatusCodes.UncertainInitialValue;
-                ValueChanged?.Invoke(variable);
             }
+        }
+
+        // Raise events outside the lock to avoid invoking handlers while holding it.
+        foreach (var variable in staleVariables)
+        {
+            ValueChanged?.Invoke(variable);
         }
     }
 

--- a/Tests/Opcilloscope.Tests/Integration/SubscriptionManagerIntegrationTests.cs
+++ b/Tests/Opcilloscope.Tests/Integration/SubscriptionManagerIntegrationTests.cs
@@ -319,8 +319,8 @@ public class SubscriptionManagerIntegrationTests : IntegrationTestBase
         // Act
         var node = await subscriptionManager.AddNodeAsync(invalidNodeId, "NonExistent");
 
-        // Assert - the subscription may still be created but with bad status
-        // The behavior depends on the server's response
-        // At minimum, ensure no exception was thrown
+        // Assert - a bad monitored item status causes AddNodeAsync to clean up
+        // and return null per its implementation contract.
+        Assert.Null(node);
     }
 }


### PR DESCRIPTION
## Summary
- Close a TOCTOU in `AddNodeAsync`: the duplicate check ran before the `ApplyChangesAsync` await, so two racing calls could both add the same node. Now the code re-checks membership under the lock after the await and, on a detected duplicate, detaches the notification handler, removes the orphaned monitored item, applies changes, and returns null.
- Detach the `Notification` handler on the monitored-item creation failure path (bad status) so the handler is no longer leaked; the new duplicate-cleanup path detaches it too.
- Remove the unused `MonitoredNode.MonitoredItemId` field and its assignment (dead code — only ever written, never read).
- `MarkAllAsStale` now mutates variables under the lock but raises `ValueChanged` events after releasing it.
- Add the missing assertion `Assert.Null(node)` to `AddNodeAsync_InvalidNodeId_ReturnsNull`, which previously asserted nothing.

## Test plan
- [x] `dotnet build Opcilloscope.sln -c Release` — 0 warnings, 0 errors
- [ ] CI: full `dotnet test` including the now-asserting `AddNodeAsync_InvalidNodeId_ReturnsNull`

---
Part of the v1 release-readiness punch list (`docs/V1-REVIEW.md`). 🤖 Generated by the `v1-fixes` workflow.
