### PR TITLE
Harden config/recent-files persistence and add RecentFilesManager tests

### DIFF
--- a/Configuration/ConfigurationService.cs
+++ b/Configuration/ConfigurationService.cs
@@ -13,6 +13,13 @@ public class ConfigurationService
 {
 
     /// <summary>
+    /// The most recently loaded configuration, retained so that fields not
+    /// surfaced by the UI (security and sampling settings) survive a
+    /// load/capture/save round-trip instead of being silently dropped.
+    /// </summary>
+    private OpcilloscopeConfig? _loadedConfig;
+
+    /// <summary>
     /// Path to the currently loaded configuration file, or null if no file is loaded.
     /// </summary>
     public string? CurrentFilePath { get; private set; }
@@ -82,6 +89,7 @@ public class ConfigurationService
         // Validate the loaded configuration
         ValidateConfiguration(config);
 
+        _loadedConfig = config;
         CurrentFilePath = filePath;
         HasUnsavedChanges = false;
         UnsavedChangesStateChanged?.Invoke(false);
@@ -128,7 +136,12 @@ public class ConfigurationService
         config.Metadata.LastModified = DateTime.UtcNow;
 
         var json = JsonSerializer.Serialize(config, OpcilloscopeJsonContext.Default.OpcilloscopeConfig);
-        await File.WriteAllTextAsync(filePath, json);
+
+        // Write atomically: write to a temp file in the same directory, then
+        // replace the target so a crash mid-write cannot corrupt the config.
+        var tempPath = filePath + ".tmp";
+        await File.WriteAllTextAsync(tempPath, json);
+        File.Move(tempPath, filePath, overwrite: true);
 
         CurrentFilePath = filePath;
         HasUnsavedChanges = false;
@@ -143,29 +156,58 @@ public class ConfigurationService
     /// <param name="monitoredVariables">The current monitored variables.</param>
     /// <param name="existingMetadata">Optional existing metadata to preserve.</param>
     /// <param name="credentials">Current connection credentials (password is never persisted).</param>
+    /// <param name="existingServer">
+    /// Optional server config whose security fields should be preserved. When null,
+    /// the most recently loaded configuration's server settings are used.
+    /// </param>
+    /// <param name="existingSettings">
+    /// Optional subscription settings whose sampling/queue fields should be preserved.
+    /// When null, the most recently loaded configuration's settings are used.
+    /// </param>
     /// <returns>A new configuration object representing the current state.</returns>
     public OpcilloscopeConfig CaptureCurrentState(
         string? endpointUrl,
         int publishingInterval,
         IEnumerable<MonitoredNode> monitoredVariables,
         ConfigMetadata? existingMetadata = null,
-        ConnectionCredentials? credentials = null)
+        ConnectionCredentials? credentials = null,
+        ServerConfig? existingServer = null,
+        SubscriptionSettings? existingSettings = null)
     {
+        // Preserve fields that the UI does not currently surface (security mode/policy,
+        // sampling interval, queue size) so a load/save round-trip does not drop them.
+        var sourceServer = existingServer ?? _loadedConfig?.Server;
+        var sourceSettings = existingSettings ?? _loadedConfig?.Settings;
+
+        var server = new ServerConfig
+        {
+            EndpointUrl = endpointUrl ?? string.Empty,
+            Authentication = new AuthenticationConfig
+            {
+                Type = (credentials?.Type ?? AuthenticationType.Anonymous).ToString(),
+                Username = credentials?.Type == AuthenticationType.UserName ? credentials.Username : null
+            }
+        };
+        if (sourceServer is not null)
+        {
+            server.SecurityMode = sourceServer.SecurityMode;
+            server.SecurityPolicy = sourceServer.SecurityPolicy;
+        }
+
+        var settings = new SubscriptionSettings
+        {
+            PublishingIntervalMs = publishingInterval
+        };
+        if (sourceSettings is not null)
+        {
+            settings.SamplingIntervalMs = sourceSettings.SamplingIntervalMs;
+            settings.QueueSize = sourceSettings.QueueSize;
+        }
+
         return new OpcilloscopeConfig
         {
-            Server = new ServerConfig
-            {
-                EndpointUrl = endpointUrl ?? string.Empty,
-                Authentication = new AuthenticationConfig
-                {
-                    Type = (credentials?.Type ?? AuthenticationType.Anonymous).ToString(),
-                    Username = credentials?.Type == AuthenticationType.UserName ? credentials.Username : null
-                }
-            },
-            Settings = new SubscriptionSettings
-            {
-                PublishingIntervalMs = publishingInterval
-            },
+            Server = server,
+            Settings = settings,
             MonitoredNodes = monitoredVariables.Select(m => new MonitoredNodeConfig
             {
                 NodeId = m.NodeId.ToString(),
@@ -185,6 +227,7 @@ public class ConfigurationService
     /// </summary>
     public void Reset()
     {
+        _loadedConfig = null;
         CurrentFilePath = null;
         HasUnsavedChanges = false;
         UnsavedChangesStateChanged?.Invoke(false);
@@ -216,7 +259,7 @@ public class ConfigurationService
     /// Gets the default directory for configuration files.
     /// Uses cross-platform appropriate locations:
     /// - Windows: %APPDATA%/opcilloscope/configs/
-    /// - macOS: ~/Library/Application Support/opcilloscope/configs/
+    /// - macOS: ~/.config/opcilloscope/configs/
     /// - Linux: ~/.config/opcilloscope/configs/
     /// </summary>
     /// <returns>Path to the default configuration directory.</returns>
@@ -233,7 +276,8 @@ public class ConfigurationService
         }
         else if (OperatingSystem.IsMacOS())
         {
-            // macOS: ~/Library/Application Support/opcilloscope/configs/
+            // macOS: ~/.config/opcilloscope/configs/
+            // (.NET maps SpecialFolder.ApplicationData to ~/.config on macOS)
             baseDir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             appFolder = "opcilloscope";
         }

--- a/Configuration/RecentFilesManager.cs
+++ b/Configuration/RecentFilesManager.cs
@@ -17,9 +17,20 @@ public class RecentFilesManager
     public event Action? FilesChanged;
 
     public RecentFilesManager()
+        : this(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData))
+    {
+    }
+
+    /// <summary>
+    /// Creates a manager that stores its settings under the given base directory.
+    /// The recent-files list is written to <c>{baseDirectory}/opcilloscope/recent-files.json</c>.
+    /// This overload exists primarily to allow tests to use an isolated directory.
+    /// </summary>
+    /// <param name="baseDirectory">Base directory under which settings are stored.</param>
+    public RecentFilesManager(string baseDirectory)
     {
         _settingsPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            baseDirectory,
             "opcilloscope",
             "recent-files.json"
         );
@@ -133,7 +144,12 @@ public class RecentFilesManager
             {
                 Directory.CreateDirectory(directory);
             }
-            File.WriteAllText(_settingsPath, JsonSerializer.Serialize(_recentFiles, OpcilloscopeJsonContext.Default.ListString));
+
+            // Write atomically: write to a temp file then replace the target so a
+            // crash mid-write cannot corrupt the recent-files list.
+            var tempPath = _settingsPath + ".tmp";
+            File.WriteAllText(tempPath, JsonSerializer.Serialize(_recentFiles, OpcilloscopeJsonContext.Default.ListString));
+            File.Move(tempPath, _settingsPath, overwrite: true);
         }
         catch (Exception ex)
         {

--- a/Tests/Opcilloscope.Tests/Configuration/ConfigurationServiceTests.cs
+++ b/Tests/Opcilloscope.Tests/Configuration/ConfigurationServiceTests.cs
@@ -718,6 +718,102 @@ public class ConfigurationServiceTests : IDisposable
 
     #endregion
 
+    #region Field Preservation Tests
+
+    [Fact]
+    public async Task LoadThenCaptureThenSave_PreservesSecurityAndSamplingFields()
+    {
+        // Arrange: a config with non-default security and sampling settings.
+        var config = CreateTestConfig();
+        config.Server.SecurityMode = "SignAndEncrypt";
+        config.Server.SecurityPolicy = "Basic256Sha256";
+        config.Settings.SamplingIntervalMs = 750;
+        config.Settings.QueueSize = 42;
+        var filePath = Path.Combine(_tempDir, "preserve.cfg");
+        await _service.SaveAsync(config, filePath);
+
+        // Act: simulate the app load -> capture current state -> save round-trip.
+        await _service.LoadAsync(filePath);
+        var captured = _service.CaptureCurrentState(
+            "opc.tcp://localhost:4840",
+            1000,
+            new List<MonitoredNode>());
+        var roundTripPath = Path.Combine(_tempDir, "preserve-roundtrip.cfg");
+        await _service.SaveAsync(captured, roundTripPath);
+        var loaded = await _service.LoadAsync(roundTripPath);
+
+        // Assert: fields not surfaced by the UI survived the round-trip.
+        Assert.Equal("SignAndEncrypt", loaded.Server.SecurityMode);
+        Assert.Equal("Basic256Sha256", loaded.Server.SecurityPolicy);
+        Assert.Equal(750, loaded.Settings.SamplingIntervalMs);
+        Assert.Equal((uint)42, loaded.Settings.QueueSize);
+    }
+
+    [Fact]
+    public void CaptureCurrentState_WithExplicitExistingServerAndSettings_PreservesFields()
+    {
+        // Arrange
+        var existingServer = new ServerConfig
+        {
+            SecurityMode = "Sign",
+            SecurityPolicy = "Aes128_Sha256_RsaOaep"
+        };
+        var existingSettings = new SubscriptionSettings
+        {
+            SamplingIntervalMs = 333,
+            QueueSize = 7
+        };
+
+        // Act
+        var config = _service.CaptureCurrentState(
+            "opc.tcp://localhost:4840",
+            1000,
+            new List<MonitoredNode>(),
+            existingServer: existingServer,
+            existingSettings: existingSettings);
+
+        // Assert
+        Assert.Equal("Sign", config.Server.SecurityMode);
+        Assert.Equal("Aes128_Sha256_RsaOaep", config.Server.SecurityPolicy);
+        Assert.Equal(333, config.Settings.SamplingIntervalMs);
+        Assert.Equal((uint)7, config.Settings.QueueSize);
+        // Publishing interval still comes from the explicit argument.
+        Assert.Equal(1000, config.Settings.PublishingIntervalMs);
+    }
+
+    [Fact]
+    public void CaptureCurrentState_NoLoadedConfig_UsesModelDefaults()
+    {
+        // Act: fresh service, no load and no explicit existing values.
+        var config = _service.CaptureCurrentState(
+            "opc.tcp://localhost:4840",
+            1000,
+            new List<MonitoredNode>());
+
+        // Assert: model defaults are used rather than throwing or nulling fields.
+        Assert.Equal("None", config.Server.SecurityMode);
+        Assert.Equal(250, config.Settings.SamplingIntervalMs);
+        Assert.Equal((uint)10, config.Settings.QueueSize);
+    }
+
+    [Fact]
+    public async Task SaveAsync_OverwritingExistingFile_LeavesNoTempFile()
+    {
+        // Arrange
+        var config = CreateTestConfig();
+        var filePath = Path.Combine(_tempDir, "atomic.cfg");
+
+        // Act: save twice to exercise the temp-file replace path.
+        await _service.SaveAsync(config, filePath);
+        await _service.SaveAsync(config, filePath);
+
+        // Assert: the atomic write left no stray temp file behind.
+        Assert.True(File.Exists(filePath));
+        Assert.False(File.Exists(filePath + ".tmp"));
+    }
+
+    #endregion
+
     private static OpcilloscopeConfig CreateTestConfig()
     {
         return new OpcilloscopeConfig

--- a/Tests/Opcilloscope.Tests/Configuration/RecentFilesManagerTests.cs
+++ b/Tests/Opcilloscope.Tests/Configuration/RecentFilesManagerTests.cs
@@ -1,0 +1,190 @@
+using Opcilloscope.Configuration;
+
+namespace Opcilloscope.Tests.Configuration;
+
+/// <summary>
+/// Tests for RecentFilesManager covering add/remove semantics, the bounded cap,
+/// and persistence across instances. Uses an isolated base directory via the
+/// test-only constructor seam so no real user settings are touched.
+/// </summary>
+public class RecentFilesManagerTests : IDisposable
+{
+    private readonly string _baseDir;
+
+    public RecentFilesManagerTests()
+    {
+        _baseDir = Path.Combine(Path.GetTempPath(), $"OpcilloscopeRecentTests_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_baseDir);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_baseDir))
+            {
+                Directory.Delete(_baseDir, true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup errors in tests
+        }
+    }
+
+    private RecentFilesManager CreateManager() => new(_baseDir);
+
+    private string MakePath(string name) => Path.Combine(_baseDir, name);
+
+    [Fact]
+    public void Add_AddsFileToFront()
+    {
+        var manager = CreateManager();
+
+        manager.Add(MakePath("a.cfg"));
+        manager.Add(MakePath("b.cfg"));
+
+        Assert.Equal(2, manager.Files.Count);
+        Assert.Equal(Path.GetFullPath(MakePath("b.cfg")), manager.Files[0]);
+        Assert.Equal(Path.GetFullPath(MakePath("a.cfg")), manager.Files[1]);
+    }
+
+    [Fact]
+    public void Add_ExistingFile_MovesToFront()
+    {
+        var manager = CreateManager();
+
+        manager.Add(MakePath("a.cfg"));
+        manager.Add(MakePath("b.cfg"));
+        manager.Add(MakePath("a.cfg"));
+
+        Assert.Equal(2, manager.Files.Count);
+        Assert.Equal(Path.GetFullPath(MakePath("a.cfg")), manager.Files[0]);
+    }
+
+    [Fact]
+    public void Add_NormalizesPaths()
+    {
+        var manager = CreateManager();
+
+        manager.Add(MakePath("sub/../a.cfg"));
+
+        Assert.Single(manager.Files);
+        Assert.Equal(Path.GetFullPath(MakePath("a.cfg")), manager.Files[0]);
+    }
+
+    [Fact]
+    public void Add_FiresFilesChanged()
+    {
+        var manager = CreateManager();
+        var fired = false;
+        manager.FilesChanged += () => fired = true;
+
+        manager.Add(MakePath("a.cfg"));
+
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void Add_BeyondCap_KeepsOnlyTenMostRecent()
+    {
+        var manager = CreateManager();
+
+        for (var i = 0; i < 15; i++)
+        {
+            manager.Add(MakePath($"file{i}.cfg"));
+        }
+
+        Assert.Equal(10, manager.Files.Count);
+        // Most recently added stays at the front.
+        Assert.Equal(Path.GetFullPath(MakePath("file14.cfg")), manager.Files[0]);
+        // The oldest entries (file0..file4) are evicted; file5 is the oldest kept.
+        Assert.Equal(Path.GetFullPath(MakePath("file5.cfg")), manager.Files[9]);
+    }
+
+    [Fact]
+    public void Remove_RemovesFile()
+    {
+        var manager = CreateManager();
+        manager.Add(MakePath("a.cfg"));
+        manager.Add(MakePath("b.cfg"));
+
+        manager.Remove(MakePath("a.cfg"));
+
+        Assert.Single(manager.Files);
+        Assert.Equal(Path.GetFullPath(MakePath("b.cfg")), manager.Files[0]);
+    }
+
+    [Fact]
+    public void Clear_RemovesAllFiles()
+    {
+        var manager = CreateManager();
+        manager.Add(MakePath("a.cfg"));
+        manager.Add(MakePath("b.cfg"));
+
+        manager.Clear();
+
+        Assert.Empty(manager.Files);
+    }
+
+    [Fact]
+    public void Add_PersistsAcrossInstances()
+    {
+        var manager = CreateManager();
+        manager.Add(MakePath("a.cfg"));
+        manager.Add(MakePath("b.cfg"));
+
+        // A fresh manager pointed at the same base directory must read the list back.
+        var reloaded = CreateManager();
+
+        Assert.Equal(2, reloaded.Files.Count);
+        Assert.Equal(Path.GetFullPath(MakePath("b.cfg")), reloaded.Files[0]);
+        Assert.Equal(Path.GetFullPath(MakePath("a.cfg")), reloaded.Files[1]);
+    }
+
+    [Fact]
+    public void Clear_PersistsAcrossInstances()
+    {
+        var manager = CreateManager();
+        manager.Add(MakePath("a.cfg"));
+        manager.Clear();
+
+        var reloaded = CreateManager();
+
+        Assert.Empty(reloaded.Files);
+    }
+
+    [Fact]
+    public void GetExistingFiles_ReturnsOnlyFilesOnDisk()
+    {
+        var manager = CreateManager();
+        var existing = MakePath("exists.cfg");
+        File.WriteAllText(existing, "{}");
+        manager.Add(existing);
+        manager.Add(MakePath("missing.cfg"));
+
+        var result = manager.GetExistingFiles();
+
+        Assert.Single(result);
+        Assert.Equal(Path.GetFullPath(existing), result[0]);
+    }
+
+    [Fact]
+    public void CleanupMissingFiles_RemovesMissingAndPersists()
+    {
+        var manager = CreateManager();
+        var existing = MakePath("exists.cfg");
+        File.WriteAllText(existing, "{}");
+        manager.Add(existing);
+        manager.Add(MakePath("missing.cfg"));
+
+        manager.CleanupMissingFiles();
+
+        Assert.Single(manager.Files);
+        Assert.Equal(Path.GetFullPath(existing), manager.Files[0]);
+
+        // Cleanup must be persisted.
+        var reloaded = CreateManager();
+        Assert.Single(reloaded.Files);
+    }
+}


### PR DESCRIPTION
## Summary
- Write configuration files and the recent-files list **atomically** (write to a `.tmp` file, then `File.Move(..., overwrite: true)`), so a crash mid-write can no longer corrupt the file.
- Preserve `SecurityMode` / `SecurityPolicy` / `SamplingIntervalMs` / `QueueSize` across a load → capture → save round-trip. `ConfigurationService` now retains the last loaded config and `CaptureCurrentState` merges those UI-invisible fields (new optional params default to the loaded config, so the existing `MainWindow` call site benefits without changes).
- Correct the macOS default-config-directory comment to `~/.config/opcilloscope/configs`.
- Add an injectable base-directory constructor seam to `RecentFilesManager` (public API otherwise unchanged) and cover it with new unit tests.

## Test plan
- [x] `dotnet build Opcilloscope.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test --filter "...ConfigurationServiceTests|...RecentFilesManagerTests"` — 62 passed, 0 failed
- [ ] Full/integration suite runs in CI

---
Part of the v1 release-readiness punch list (`docs/V1-REVIEW.md`). 🤖 Generated by the `v1-fixes` workflow.
