### PR TITLE
Add pure unit tests for NodeAttributeFormatter and FocusManager

### DIFF
--- a/App/FocusManager.cs
+++ b/App/FocusManager.cs
@@ -93,8 +93,7 @@ public class FocusManager
     public void FocusNext()
     {
         var currentIndex = _currentPane != null ? Array.IndexOf(_panes, _currentPane) : -1;
-        var nextIndex = (currentIndex + 1) % _panes.Length;
-        FocusPane(nextIndex);
+        FocusPane(GetNextIndex(currentIndex, _panes.Length));
     }
 
     /// <summary>
@@ -103,7 +102,24 @@ public class FocusManager
     public void FocusPrevious()
     {
         var currentIndex = _currentPane != null ? Array.IndexOf(_panes, _currentPane) : 0;
-        var prevIndex = (currentIndex - 1 + _panes.Length) % _panes.Length;
-        FocusPane(prevIndex);
+        FocusPane(GetPreviousIndex(currentIndex, _panes.Length));
+    }
+
+    /// <summary>
+    /// Computes the index of the next pane in tab order, wrapping around to the
+    /// first pane after the last. Pure helper extracted for testability.
+    /// </summary>
+    internal static int GetNextIndex(int currentIndex, int paneCount)
+    {
+        return (currentIndex + 1) % paneCount;
+    }
+
+    /// <summary>
+    /// Computes the index of the previous pane in tab order, wrapping around to the
+    /// last pane before the first. Pure helper extracted for testability.
+    /// </summary>
+    internal static int GetPreviousIndex(int currentIndex, int paneCount)
+    {
+        return (currentIndex - 1 + paneCount) % paneCount;
     }
 }

--- a/Tests/Opcilloscope.Tests/App/FocusManagerTests.cs
+++ b/Tests/Opcilloscope.Tests/App/FocusManagerTests.cs
@@ -1,0 +1,118 @@
+using Opcilloscope.App;
+
+namespace Opcilloscope.Tests.App;
+
+/// <summary>
+/// Pure unit tests for the FocusManager next/prev index ordering logic.
+/// These exercise the extracted index helpers directly and do not start the
+/// Terminal.Gui application loop.
+/// </summary>
+public class FocusManagerTests
+{
+    // ── GetNextIndex ──
+
+    [Theory]
+    [InlineData(0, 3, 1)]
+    [InlineData(1, 3, 2)]
+    [InlineData(2, 3, 0)] // wrap around past the last pane
+    public void GetNextIndex_AdvancesAndWrapsAround(int currentIndex, int paneCount, int expected)
+    {
+        var result = FocusManager.GetNextIndex(currentIndex, paneCount);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetNextIndex_FromNoSelection_ReturnsFirstPane()
+    {
+        // FocusNext treats "no current pane" as index -1 so the first Next lands on pane 0.
+        var result = FocusManager.GetNextIndex(-1, 3);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void GetNextIndex_SinglePane_StaysOnPaneZero()
+    {
+        var result = FocusManager.GetNextIndex(0, 1);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void GetNextIndex_FullCycle_VisitsEveryPaneInOrder()
+    {
+        const int paneCount = 4;
+        var visited = new List<int>();
+        var index = -1;
+
+        for (var i = 0; i < paneCount; i++)
+        {
+            index = FocusManager.GetNextIndex(index, paneCount);
+            visited.Add(index);
+        }
+
+        Assert.Equal(new[] { 0, 1, 2, 3 }, visited);
+        // One more step wraps back to the start.
+        Assert.Equal(0, FocusManager.GetNextIndex(index, paneCount));
+    }
+
+    // ── GetPreviousIndex ──
+
+    [Theory]
+    [InlineData(2, 3, 1)]
+    [InlineData(1, 3, 0)]
+    [InlineData(0, 3, 2)] // wrap around before the first pane
+    public void GetPreviousIndex_RetreatsAndWrapsAround(int currentIndex, int paneCount, int expected)
+    {
+        var result = FocusManager.GetPreviousIndex(currentIndex, paneCount);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetPreviousIndex_FromNoSelection_ReturnsLastPane()
+    {
+        // FocusPrevious treats "no current pane" as index 0 so the first Previous wraps to the last pane.
+        var result = FocusManager.GetPreviousIndex(0, 3);
+
+        Assert.Equal(2, result);
+    }
+
+    [Fact]
+    public void GetPreviousIndex_SinglePane_StaysOnPaneZero()
+    {
+        var result = FocusManager.GetPreviousIndex(0, 1);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void GetPreviousIndex_FullCycle_VisitsEveryPaneInReverseOrder()
+    {
+        const int paneCount = 4;
+        var visited = new List<int>();
+        var index = 0;
+
+        // Starting from "no selection" (index 0) the first step wraps to the last pane.
+        for (var i = 0; i < paneCount; i++)
+        {
+            index = FocusManager.GetPreviousIndex(index, paneCount);
+            visited.Add(index);
+        }
+
+        Assert.Equal(new[] { 3, 2, 1, 0 }, visited);
+    }
+
+    [Fact]
+    public void NextThenPrevious_ReturnsToOriginalPane()
+    {
+        const int paneCount = 5;
+        const int start = 2;
+
+        var next = FocusManager.GetNextIndex(start, paneCount);
+        var back = FocusManager.GetPreviousIndex(next, paneCount);
+
+        Assert.Equal(start, back);
+    }
+}

--- a/Tests/Opcilloscope.Tests/Utilities/NodeAttributeFormatterTests.cs
+++ b/Tests/Opcilloscope.Tests/Utilities/NodeAttributeFormatterTests.cs
@@ -1,0 +1,314 @@
+using Opc.Ua;
+using Opcilloscope.Utilities;
+
+namespace Opcilloscope.Tests.Utilities;
+
+/// <summary>
+/// Pure unit tests for <see cref="NodeAttributeFormatter"/>. These build attribute
+/// dictionaries and assert on the rendered, human-readable output. No OPC server or
+/// Terminal.Gui loop is required.
+/// </summary>
+public class NodeAttributeFormatterTests
+{
+    // ── Header & sections ──
+
+    [Fact]
+    public void Format_AlwaysIncludesHeaderAndIdentitySection()
+    {
+        var output = NodeAttributeFormatter.Format(new Dictionary<string, object?>());
+
+        Assert.Contains("OPC UA Node Attributes", output);
+        Assert.Contains("── Identity ──", output);
+        Assert.Contains("Copied:", output);
+    }
+
+    [Fact]
+    public void Format_OmitsSectionsWhenNoKeysPresent()
+    {
+        var output = NodeAttributeFormatter.Format(new Dictionary<string, object?>());
+
+        Assert.DoesNotContain("── Access ──", output);
+        Assert.DoesNotContain("── Value ──", output);
+        Assert.DoesNotContain("── Type ──", output);
+        Assert.DoesNotContain("── Method ──", output);
+        Assert.DoesNotContain("── Permissions ──", output);
+    }
+
+    [Fact]
+    public void Format_OmitsAttributesWithNullValues()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["NodeId"] = null,
+            ["DisplayName"] = new LocalizedText("Visible Node"),
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        // NodeId is null so its label should not be rendered as a value line.
+        Assert.DoesNotContain("NodeId   ", output);
+        Assert.Contains("Visible Node", output);
+    }
+
+    // ── Identity / default formatting ──
+
+    [Fact]
+    public void Format_LocalizedText_RendersTextOnly()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["DisplayName"] = new LocalizedText("Temperature Sensor"),
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("Temperature Sensor", output);
+    }
+
+    [Fact]
+    public void Format_QualifiedNameBrowseName_RendersToString()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["BrowseName"] = new QualifiedName("Counter", 2),
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("2:Counter", output);
+    }
+
+    [Fact]
+    public void Format_NodeId_RendersToString()
+    {
+        var nodeId = new NodeId("Counter", 2);
+        var attributes = new Dictionary<string, object?>
+        {
+            ["NodeId"] = nodeId,
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains(nodeId.ToString()!, output);
+    }
+
+    // ── Access section ──
+
+    [Fact]
+    public void Format_AccessLevel_RendersFlagsAndHex()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["AccessLevel"] = (byte)0x03, // Read | Write
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("── Access ──", output);
+        Assert.Contains("Read | Write (0x03)", output);
+    }
+
+    [Fact]
+    public void Format_AccessLevel_Zero_RendersNone()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["AccessLevel"] = (byte)0x00,
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("None (0x00)", output);
+    }
+
+    [Fact]
+    public void Format_AccessLevelEx_RendersExtendedFlags()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            // Read | NonatomicRead
+            ["AccessLevelEx"] = (uint)0x101,
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("Read | NonatomicRead (0x00000101)", output);
+    }
+
+    [Fact]
+    public void Format_WriteMask_Zero_RendersNone()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["WriteMask"] = (uint)0,
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("None (0)", output);
+    }
+
+    [Fact]
+    public void Format_WriteMask_RendersFlags()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            // AccessLevel (0x01) | DataType (0x10)
+            ["WriteMask"] = (uint)0x11,
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("AccessLevel | DataType (0x11)", output);
+    }
+
+    [Fact]
+    public void Format_EventNotifier_RendersFlags()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["EventNotifier"] = (byte)0x01, // SubscribeToEvents
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("SubscribeToEvents (0x01)", output);
+    }
+
+    // ── Value section ──
+
+    [Fact]
+    public void Format_Value_StringIsQuoted()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["Value"] = "hello",
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("── Value ──", output);
+        Assert.Contains("\"hello\"", output);
+    }
+
+    [Fact]
+    public void Format_Value_DataValueWithBadStatus_RendersBadCode()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["Value"] = new DataValue { StatusCode = new StatusCode(StatusCodes.BadNodeIdUnknown) },
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains($"(bad: 0x{StatusCodes.BadNodeIdUnknown:X8})", output);
+    }
+
+    [Fact]
+    public void Format_Value_DataValueWithGoodStatus_UnwrapsValue()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["Value"] = new DataValue(new Variant(42)),
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("42", output);
+    }
+
+    [Fact]
+    public void Format_Value_ByteArray_RendersByteCount()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["Value"] = new byte[] { 1, 2, 3, 4 },
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("[4 bytes]", output);
+    }
+
+    [Fact]
+    public void Format_Value_SmallArray_RendersElements()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["Value"] = new int[] { 1, 2, 3 },
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("[1, 2, 3]", output);
+    }
+
+    [Fact]
+    public void Format_Value_LargeArray_RendersElementCount()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["Value"] = new int[] { 1, 2, 3, 4, 5, 6, 7 },
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("[7 elements]", output);
+    }
+
+    [Fact]
+    public void Format_ValueRank_RendersNamedRank()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["ValueRank"] = -1,
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("Scalar (-1)", output);
+    }
+
+    [Fact]
+    public void Format_ArrayDimensions_RendersDimensions()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["ArrayDimensions"] = new uint[] { 3, 4 },
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("[3, 4]", output);
+    }
+
+    [Fact]
+    public void Format_MinimumSamplingInterval_AppendsMilliseconds()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            ["MinimumSamplingInterval"] = 500.0,
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("500 ms", output);
+    }
+
+    // ── Permissions section ──
+
+    [Fact]
+    public void Format_AccessRestrictions_RendersFlagsAndHex()
+    {
+        var attributes = new Dictionary<string, object?>
+        {
+            // SigningRequired (0x01) | EncryptionRequired (0x02)
+            ["AccessRestrictions"] = (ushort)0x03,
+        };
+
+        var output = NodeAttributeFormatter.Format(attributes);
+
+        Assert.Contains("── Permissions ──", output);
+        Assert.Contains("SigningRequired | EncryptionRequired (0x0003)", output);
+    }
+}


### PR DESCRIPTION
## Summary
- Add 22 pure unit tests for `NodeAttributeFormatter.Format`, covering the header/Identity section, conditional section omission, null-attribute skipping, and every decoder path: AccessLevel, AccessLevelEx, WriteMask (incl. zero/None), EventNotifier, ValueRank, ArrayDimensions, AccessRestrictions, plus value rendering for DataValue (good/bad status), strings, byte arrays, small/large arrays, MinimumSamplingInterval, and default formatting of LocalizedText / QualifiedName / NodeId. No source change needed.
- Extract the next/prev index arithmetic from `FocusManager` into pure `internal static GetNextIndex`/`GetPreviousIndex` helpers (behavior-preserving). Add 13 tests for advance, retreat, wrap-around, single-pane, no-selection semantics, full-cycle ordering, and round trips.
- Both test files are pure unit tests: no OPC UA server, no Terminal.Gui application loop.

## Test plan
- [x] `dotnet build Opcilloscope.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test --filter "...FocusManagerTests|...NodeAttributeFormatterTests"` — 35 passed, 0 failed
- [ ] Full suite runs in CI

---
Part of the v1 release-readiness punch list (`docs/V1-REVIEW.md`). 🤖 Generated by the `v1-fixes` workflow.
