### PR TITLE
Fix release packaging: MinVer tag prefix, disable trimming, deep checkout, publish smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # MinVer needs the full commit history (and tags) to compute versions.
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -27,3 +30,12 @@ jobs:
 
       - name: Test
         run: dotnet test --no-build --configuration Release --verbosity normal
+
+      - name: Publish (smoke)
+        run: dotnet publish Opcilloscope.csproj -c Release -r linux-x64 -o ./publish
+
+      - name: Smoke test published binary
+        run: |
+          chmod +x ./publish/opcilloscope
+          ./publish/opcilloscope --help
+          echo "Published binary exited with code $?"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,10 @@ jobs:
       - name: Smoke test published binary
         run: |
           chmod +x ./publish/opcilloscope
-          ./publish/opcilloscope --help
-          echo "Published binary exited with code $?"
+          # Run --help under a pseudo-tty: this exercises Terminal.Gui's Application.Init
+          # (catching trim/startup regressions in the self-contained binary) and then exits
+          # via the --help path. `script -e` propagates the binary's exit code.
+          TERM=xterm script -qec "./publish/opcilloscope --help" /dev/null
+          code=$?
+          echo "Published binary exited with code $code"
+          test "$code" -eq 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,15 @@ jobs:
           - os: ubuntu-latest
             rid: linux-x64
             artifact: opcilloscope-linux-x64
+            # smoke: runs the published binary natively on the host runner
+            smoke: true
           - os: ubuntu-latest
             rid: linux-arm64
             artifact: opcilloscope-linux-arm64
           - os: windows-latest
             rid: win-x64
             artifact: opcilloscope-win-x64
+            smoke: true
           - os: windows-latest
             rid: win-arm64
             artifact: opcilloscope-win-arm64
@@ -31,12 +34,16 @@ jobs:
           - os: macos-latest
             rid: osx-arm64
             artifact: opcilloscope-osx-arm64
+            smoke: true
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # MinVer needs the full commit history (and tags) to compute versions.
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -49,6 +56,19 @@ jobs:
       - name: Publish
         run: |
           dotnet publish Opcilloscope.csproj -c Release -r ${{ matrix.rid }} -o ./publish
+
+      - name: Smoke test published binary (Linux/macOS)
+        if: matrix.smoke && runner.os != 'Windows'
+        run: |
+          chmod +x ./publish/opcilloscope
+          ./publish/opcilloscope --help
+          echo "Published binary exited with code $?"
+
+      - name: Smoke test published binary (Windows)
+        if: matrix.smoke && runner.os == 'Windows'
+        run: |
+          ./publish/opcilloscope.exe --help
+          if ($LASTEXITCODE -ne 0) { throw "Published binary exited with code $LASTEXITCODE" }
 
       - name: Create archive (Linux/macOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,12 @@ jobs:
         if: matrix.smoke && runner.os != 'Windows'
         run: |
           chmod +x ./publish/opcilloscope
-          ./publish/opcilloscope --help
-          echo "Published binary exited with code $?"
+          # Run under a pseudo-tty so Terminal.Gui's Application.Init can initialize even on
+          # a headless runner; `script -e` propagates the binary's exit code.
+          TERM=xterm script -qec "./publish/opcilloscope --help" /dev/null
+          code=$?
+          echo "Published binary exited with code $code"
+          test "$code" -eq 0
 
       - name: Smoke test published binary (Windows)
         if: matrix.smoke && runner.os == 'Windows'

--- a/Opcilloscope.csproj
+++ b/Opcilloscope.csproj
@@ -10,6 +10,7 @@
     <InvariantGlobalization>true</InvariantGlobalization>
 
     <!-- Package metadata (Version is driven by MinVer from Git tags) -->
+    <MinVerTagPrefix>v</MinVerTagPrefix>
     <Authors>Brett Kinny</Authors>
     <Description>A lightweight terminal-based OPC UA client for browsing, monitoring, and subscribing to industrial automation data.</Description>
     <PackageProjectUrl>https://github.com/SquareWaveSystems/opcilloscope</PackageProjectUrl>
@@ -22,8 +23,11 @@
     <!-- Publishing options -->
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <PublishTrimmed>true</PublishTrimmed>
-    <TrimMode>partial</TrimMode>
+    <!-- Trimming is disabled: the OPC Foundation and Terminal.Gui stack relies
+         heavily on reflection and is not trim-safe. PublishTrimmed produced 23 trim
+         warnings and a runtime "$schema" deserialization failure on launch, leaving a
+         broken binary. Keep SelfContained + PublishSingleFile for distribution. -->
+    <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- **[blocker]** Add `<MinVerTagPrefix>v</MinVerTagPrefix>` to `Opcilloscope.csproj` so `v`-prefixed git tags (v0.5.0, future v1.0.0) drive the version instead of falling back to `0.0.0-alpha`.
- Disable `<PublishTrimmed>` (set to `false`) and drop the now-irrelevant `<TrimMode>` while keeping `SelfContained` and `PublishSingleFile`. The reflection-heavy OPC Foundation / Terminal.Gui stack is not trim-safe — trimming produced 23 warnings and a runtime `$schema` deserialization failure on launch. A comment in the csproj records why.
- Add `fetch-depth: 0` to the `actions/checkout` step in both `ci.yml` and `release.yml` so MinVer has full history/tags.
- Add a post-publish smoke step that runs the published binary with `--help` and asserts exit 0 (gated in `release.yml` to RIDs that run natively on their host runner; lightweight equivalent in `ci.yml`).

## Test plan
- [x] `dotnet build Opcilloscope.sln -c Release` — 0 warnings, 0 errors
- [x] `opcilloscope --help` returns exit code 0
- [ ] CI: confirm the publish + smoke steps pass on the linux-x64 runner
- [ ] Release: tag a `v*` release and confirm the stamped version matches (no `0.0.0-alpha`) and the binary launches without the `$schema` error

---
Part of the v1 release-readiness punch list (`docs/V1-REVIEW.md`). Resolves the one release **blocker**. 🤖 Generated by the `v1-fixes` workflow.
