### PR TITLE
Fix connection lifecycle: transfer-before-dispose reconnect, async connect teardown, truthful config load

### DIFF
--- a/App/MainWindow.cs
+++ b/App/MainWindow.cs
@@ -1207,9 +1207,6 @@ License: MIT
 
             var config = await _configService.LoadAsync(filePath);
 
-            // Store metadata
-            _currentMetadata = config.Metadata;
-
             // Connect to server and subscribe to nodes
             if (!string.IsNullOrEmpty(config.Server.EndpointUrl))
             {
@@ -1226,6 +1223,11 @@ License: MIT
 
                     if (!pwDialog.Confirmed)
                     {
+                        // Nothing was torn down, but the load already switched the Ctrl+S
+                        // target to this file; revert to untitled so a save cannot write
+                        // the still-running session's state over it.
+                        _configService.Reset();
+                        UpdateWindowTitle();
                         _logger.Info("Password prompt cancelled - skipping connection");
                         return;
                     }
@@ -1236,16 +1238,17 @@ License: MIT
                         pwDialog.Password);
                 }
 
+                // Tear down the current session first: stops any active recording and
+                // clears the views, so the UI cannot keep showing dead rows from the
+                // old server while (or after) the new connection is attempted.
+                await DisconnectAsync();
+
                 var connected = await _connectionManager.ConnectAsync(config.Server.EndpointUrl, config.Settings.PublishingIntervalMs, credentials);
 
                 if (connected)
                 {
                     _lastEndpoint = config.Server.EndpointUrl;
-
-                    // Only after successful connection, disconnect old and clear views
-                    _addressSpaceView.Clear();
-                    _monitoredVariablesView.Clear();
-                    _nodeDetailsView.Clear();
+                    _currentMetadata = config.Metadata;
 
                     _addressSpaceView.Initialize(_connectionManager.NodeBrowser);
 
@@ -1271,24 +1274,25 @@ License: MIT
                 }
                 else
                 {
+                    // Revert to untitled: leaving the failed file as the Ctrl+S target
+                    // would let a save overwrite it with the now-empty session state.
+                    _configService.Reset();
+                    _currentMetadata = null;
+                    UpdateWindowTitle();
+
                     _logger.Error($"Failed to connect to {config.Server.EndpointUrl}");
-                    MessageBox.ErrorQuery("Connection Failed", 
-                        $"Could not connect to server:\n{config.Server.EndpointUrl}\n\nThe previous connection and data have been preserved.", 
+                    MessageBox.ErrorQuery("Connection Failed",
+                        $"Could not connect to server:\n{config.Server.EndpointUrl}\n\nThe previous connection has been closed. Use Connect to reconnect.",
                         "OK");
                 }
             }
             else
             {
-                // No endpoint URL, just clear views and apply settings
-                if (_connectionManager.IsConnected)
-                {
-                    await _connectionManager.DisconnectAsync();
-                }
+                // No endpoint URL: tear down any current session (stops recording,
+                // clears views) and just adopt the loaded settings.
+                await DisconnectAsync();
 
-                _addressSpaceView.Clear();
-                _monitoredVariablesView.Clear();
-                _nodeDetailsView.Clear();
-                
+                _currentMetadata = config.Metadata;
                 _recentFiles.Add(filePath);
                 UpdateWindowTitle();
                 _logger.Info("Configuration loaded (no server connection)");

--- a/OpcUa/ConnectionManager.cs
+++ b/OpcUa/ConnectionManager.cs
@@ -123,7 +123,10 @@ public sealed class ConnectionManager : IDisposable
         string? securityMode = null,
         string? securityPolicy = null)
     {
-        Disconnect();
+        // Async teardown: the synchronous Disconnect() blocks on the OPC UA close
+        // round-trip (up to the transport timeout against a dead server), which froze
+        // the UI thread when reconnecting over an existing or dead connection.
+        await DisconnectAsync();
 
         _lastEndpoint = endpoint;
         _credentials = credentials ?? ConnectionCredentials.Anonymous;
@@ -135,7 +138,17 @@ public sealed class ConnectionManager : IDisposable
 
             if (success)
             {
-                await InitializeSubscriptionAsync(publishingInterval);
+                if (!await InitializeSubscriptionAsync(publishingInterval))
+                {
+                    // Without a subscription the session is useless for monitoring;
+                    // fail the connect rather than reporting Connected.
+                    var msg = "Connected, but the server refused the monitoring subscription. Disconnecting.";
+                    _logger.Error(msg);
+                    ConnectionError?.Invoke(msg);
+                    await DisconnectAsync();
+                    return false;
+                }
+
                 StateChanged?.Invoke(ConnectionState.Connected);
             }
             else
@@ -300,11 +313,11 @@ public sealed class ConnectionManager : IDisposable
         return _client.WriteValueAsync(nodeId, value);
     }
 
-    private async Task InitializeSubscriptionAsync(int publishingInterval = 250)
+    private async Task<bool> InitializeSubscriptionAsync(int publishingInterval = 250)
     {
         _subscriptionManager = new SubscriptionManager(_client, _logger);
         _subscriptionManager.PublishingInterval = publishingInterval;
-        await _subscriptionManager.InitializeAsync();
+        var initialized = await _subscriptionManager.InitializeAsync();
 
         // Store handler references for proper unsubscription
         _valueChangedHandler = node => ValueChanged?.Invoke(node);
@@ -314,6 +327,8 @@ public sealed class ConnectionManager : IDisposable
         _subscriptionManager.ValueChanged += _valueChangedHandler;
         _subscriptionManager.VariableAdded += _variableAddedHandler;
         _subscriptionManager.VariableRemoved += _variableRemovedHandler;
+
+        return initialized;
     }
 
     private void DisposeSubscription()

--- a/OpcUa/OpcUaClientWrapper.cs
+++ b/OpcUa/OpcUaClientWrapper.cs
@@ -446,25 +446,32 @@ public class OpcUaClientWrapper : IDisposable
             // session; if that session is already disposed this throws, the SDK swallows it
             // and reports failure - after the server-side transfer already succeeded - leaving
             // orphaned subscriptions on the server and forcing a duplicate recreate.
-            if (subscriptionsToTransfer != null && subscriptionsToTransfer.Count > 0)
+            try
             {
-                var transferred = await TransferSubscriptionsAsync(subscriptionsToTransfer);
-                _logger.Info($"Transferred {transferred} of {subscriptionsToTransfer.Count} subscription(s)");
-            }
-
-            // Retire the old session. Dispose without CloseAsync() - sending CloseSession
-            // would delete any server-side subscriptions that were not transferred, and the
-            // transport is typically already dead on this path.
-            if (oldSession != null)
-            {
-                oldSession.KeepAlive -= Session_KeepAlive;
-                try
+                if (subscriptionsToTransfer != null && subscriptionsToTransfer.Count > 0)
                 {
-                    oldSession.Dispose();
+                    var transferred = await TransferSubscriptionsAsync(subscriptionsToTransfer);
+                    _logger.Info($"Transferred {transferred} of {subscriptionsToTransfer.Count} subscription(s)");
                 }
-                catch (Exception ex)
+            }
+            finally
+            {
+                // Retire the old session even if the transfer throws - once _session
+                // points at the new session the old one would otherwise leak. Dispose
+                // without CloseAsync() - sending CloseSession would delete any
+                // server-side subscriptions that were not transferred, and the
+                // transport is typically already dead on this path.
+                if (oldSession != null)
                 {
-                    _logger.Warning($"Session cleanup error during reconnection: {ex.Message}");
+                    oldSession.KeepAlive -= Session_KeepAlive;
+                    try
+                    {
+                        oldSession.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Warning($"Session cleanup error during reconnection: {ex.Message}");
+                    }
                 }
             }
 

--- a/OpcUa/OpcUaClientWrapper.cs
+++ b/OpcUa/OpcUaClientWrapper.cs
@@ -181,7 +181,7 @@ public class OpcUaClientWrapper : IDisposable
     {
         try
         {
-            Disconnect();
+            await DisconnectAsync();
 
             _credentials = credentials ?? ConnectionCredentials.Anonymous;
             _securityMode = securityMode;
@@ -231,14 +231,14 @@ public class OpcUaClientWrapper : IDisposable
                 : "Authentication rejected by server: " + sre.Message;
             _logger.Error(msg);
             ConnectionError?.Invoke(msg);
-            Disconnect();
+            await DisconnectAsync();
             return false;
         }
         catch (Exception ex)
         {
             _logger.Error($"Connection failed: {ex.Message}");
             ConnectionError?.Invoke(ex.Message);
-            Disconnect();
+            await DisconnectAsync();
             return false;
         }
     }
@@ -406,31 +406,14 @@ public class OpcUaClientWrapper : IDisposable
 
             var config = await GetApplicationConfigAsync();
 
-            // Capture existing subscriptions before closing old session
-            SubscriptionCollection? subscriptionsToTransfer = null;
-            if (_session?.Subscriptions != null && _session.Subscriptions.Any())
-            {
-                subscriptionsToTransfer = new SubscriptionCollection(_session.Subscriptions);
-                _logger.Info($"Captured {subscriptionsToTransfer.Count} subscription(s) for transfer");
-            }
+            var oldSession = _session;
 
-            // Clean up old session without deleting subscriptions on server
-            if (_session != null)
+            // Capture existing subscriptions before replacing the session
+            SubscriptionCollection? subscriptionsToTransfer = null;
+            if (oldSession?.Subscriptions != null && oldSession.Subscriptions.Any())
             {
-                _session.KeepAlive -= Session_KeepAlive;
-                try
-                {
-                    // Dispose without CloseAsync() - this intentionally skips sending CloseSession
-                    // to the server, allowing server-side subscriptions to remain active for transfer.
-                    // With DeleteSubscriptionsOnClose=false, we want the subscriptions to persist
-                    // on the server so we can transfer them to the new session.
-                    _session.Dispose();
-                }
-                catch (Exception ex)
-                {
-                    _logger.Warning($"Session cleanup error during reconnection: {ex.Message}");
-                }
-                _session = null;
+                subscriptionsToTransfer = new SubscriptionCollection(oldSession.Subscriptions);
+                _logger.Info($"Captured {subscriptionsToTransfer.Count} subscription(s) for transfer");
             }
 
             // Rediscover endpoint in case server configuration changed
@@ -439,9 +422,10 @@ public class OpcUaClientWrapper : IDisposable
             var endpoint = new ConfiguredEndpoint(null, selectedEndpoint, endpointConfig);
             _lastConfiguredEndpoint = endpoint;
 
-            // Create new session
+            // Create the new session before touching the old one, so a failure here
+            // leaves the existing state unchanged for the next retry attempt.
 #pragma warning disable CS0618
-            _session = await Opc.Ua.Client.Session.Create(
+            var newSession = await Opc.Ua.Client.Session.Create(
                 config,
                 endpoint,
                 false,
@@ -452,18 +436,39 @@ public class OpcUaClientWrapper : IDisposable
             );
 #pragma warning restore CS0618
 
-            _session.DeleteSubscriptionsOnClose = false;
-            _session.TransferSubscriptionsOnReconnect = true;
-            _session.KeepAlive += Session_KeepAlive;
+            newSession.DeleteSubscriptionsOnClose = false;
+            newSession.TransferSubscriptionsOnReconnect = true;
+            newSession.KeepAlive += Session_KeepAlive;
+            _session = newSession;
 
-            // Transfer subscriptions to new session
+            // Transfer subscriptions while the old session is still alive. The client-side
+            // half of TransferSubscriptionsAsync detaches each subscription from its previous
+            // session; if that session is already disposed this throws, the SDK swallows it
+            // and reports failure - after the server-side transfer already succeeded - leaving
+            // orphaned subscriptions on the server and forcing a duplicate recreate.
             if (subscriptionsToTransfer != null && subscriptionsToTransfer.Count > 0)
             {
                 var transferred = await TransferSubscriptionsAsync(subscriptionsToTransfer);
                 _logger.Info($"Transferred {transferred} of {subscriptionsToTransfer.Count} subscription(s)");
             }
 
-            return _session.Connected;
+            // Retire the old session. Dispose without CloseAsync() - sending CloseSession
+            // would delete any server-side subscriptions that were not transferred, and the
+            // transport is typically already dead on this path.
+            if (oldSession != null)
+            {
+                oldSession.KeepAlive -= Session_KeepAlive;
+                try
+                {
+                    oldSession.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warning($"Session cleanup error during reconnection: {ex.Message}");
+                }
+            }
+
+            return newSession.Connected;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
Fixes the three connection-lifecycle gate items from the v1.0 follow-up review (`docs/V1-REVIEW-FOLLOWUP.md`, items 2–4, plus the related subscription-init swallow).

- **Transfer-before-dispose on reconnect:** `TryRecreateSessionAsync` previously disposed the old session *before* transferring subscriptions. The client-side half of `TransferSubscriptionsAsync` must detach each subscription from its previous session, which threw on the disposed session — *after* the server-side transfer had already succeeded — so the SDK reported failure and the app recreated a duplicate subscription set, orphaning the transferred ones on the server on every hard reconnect. The new session is now created and the transfer completed while the old session is still alive; the old session is disposed afterwards (still without `CloseSession`, so untransferred server-side subscriptions are not deleted). A failure during session creation now leaves existing state untouched for the next retry.
- **No more UI-thread freeze on re-connect:** `ConnectionManager.ConnectAsync` and `OpcUaClientWrapper.ConnectAsync` (including its error paths) now `await DisconnectAsync()` instead of calling the synchronous `Disconnect()`, which blocked the calling (UI) thread on the OPC UA close round-trip — up to the 30 s transport timeout when connecting away from a dead server. The sync `Disconnect()` remains for back-compat callers.
- **Connected means usable:** `ConnectionManager.ConnectAsync` no longer ignores the result of subscription initialization. If the server refuses the monitoring subscription, it raises `ConnectionError`, disconnects, and returns false instead of reporting Connected on a session that can never monitor anything.
- **Truthful config load:** `MainWindow.LoadConfigurationAsync` now tears down the old session up front via the recording-aware `DisconnectAsync()` (stops a live CSV recording — no more zombie REC indicator — and clears the views, so no dead rows survive). On a failed connect or a cancelled password prompt, the config service is reset to *untitled* so Ctrl+S can no longer silently overwrite the newly selected file with stale session state, and the failure dialog no longer claims "the previous connection and data have been preserved" when they weren't.

## Behavior changes
- A config load that fails to connect now leaves the app cleanly disconnected and untitled, instead of showing stale data with a misleading dialog. Re-loading the previous file restores the old session.
- A connect whose subscription creation fails now surfaces as a failed connect rather than a silent half-connected state.

## Test plan
- [x] `dotnet build Opcilloscope.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test -c Release` — 613/613 passing, including the existing `ReconnectIntegrationTests` which exercise the recreate path
- [ ] Manual: kill the server mid-session → auto-reconnect resumes without duplicated subscriptions in server diagnostics; connect to a new server while the old one is dead → UI stays responsive; load a config with a bad endpoint while connected and recording → recording stopped, views cleared, dialog truthful, Ctrl+S prompts Save As

---
Part of the v1 follow-up punch list (`docs/V1-REVIEW-FOLLOWUP.md`, items 2–4).

https://claude.ai/code/session_012Vopnd9vWkzELveHRgZhie

---
_Generated by [Claude Code](https://claude.ai/code/session_012Vopnd9vWkzELveHRgZhie)_