### PR TITLE
Fix NodeBrowser data-type cache: concurrent access race and useless per-variable keying

### DIFF
--- a/OpcUa/NodeBrowser.cs
+++ b/OpcUa/NodeBrowser.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Opc.Ua;
 using Opcilloscope.OpcUa.Models;
 using Opcilloscope.Utilities;
@@ -11,7 +12,10 @@ public class NodeBrowser
 {
     private readonly OpcUaClientWrapper _client;
     private readonly Logger _logger;
-    private readonly Dictionary<string, string> _dataTypeCache = new();
+    // Keyed by the data type's NodeId (not the variable's) so variables sharing a type
+    // reuse the same lookup. ConcurrentDictionary because GetChildrenAsync resolves
+    // data type names for multiple variables in parallel.
+    private readonly ConcurrentDictionary<string, string> _dataTypeCache = new();
 
     // Common data type NodeIds
     private static readonly Dictionary<uint, string> BuiltInDataTypes = new()
@@ -133,34 +137,26 @@ public class NodeBrowser
 
     private async Task<string?> GetDataTypeNameAsync(NodeId nodeId)
     {
-        var key = nodeId.ToString();
-        if (_dataTypeCache.TryGetValue(key, out var cached))
-            return cached;
-
         try
         {
             var attrs = await _client.ReadAttributesAsync(nodeId, Attributes.DataType);
             if (attrs.Count > 0 && attrs[0].Value is NodeId dataTypeId)
             {
-                string? name = null;
-
-                // Check built-in types first
+                // Check built-in types first - already a dictionary lookup, no caching needed
                 if (dataTypeId.NamespaceIndex == 0 && dataTypeId.IdType == IdType.Numeric)
                 {
                     var id = (uint)dataTypeId.Identifier;
                     if (BuiltInDataTypes.TryGetValue(id, out var builtIn))
-                        name = builtIn;
+                        return builtIn;
                 }
+
+                var key = dataTypeId.ToString();
+                if (_dataTypeCache.TryGetValue(key, out var cached))
+                    return cached;
 
                 // If not built-in, browse for the type name
-                if (name == null)
-                {
-                    var typeAttrs = await _client.ReadAttributesAsync(dataTypeId, Attributes.DisplayName);
-                    if (typeAttrs.Count > 0 && typeAttrs[0].Value is LocalizedText lt)
-                        name = lt.Text;
-                }
-
-                if (name != null)
+                var typeAttrs = await _client.ReadAttributesAsync(dataTypeId, Attributes.DisplayName);
+                if (typeAttrs.Count > 0 && typeAttrs[0].Value is LocalizedText lt && lt.Text is string name)
                 {
                     _dataTypeCache[key] = name;
                     return name;


### PR DESCRIPTION
## Summary
Fixes the NodeBrowser data race from the v1.0 follow-up review (`docs/V1-REVIEW-FOLLOWUP.md`, item 5).

- `_dataTypeCache` is now a `ConcurrentDictionary<string, string>`. Previously it was a plain `Dictionary` read and written concurrently by the per-variable tasks `GetChildrenAsync` fans out via `Task.WhenAll` — expanding any folder with ≥2 variables raced it, risking thrown exceptions (swallowed per node) or silent, permanent corruption of the cache.
- The cache is now keyed by the **data type's** NodeId instead of the variable's. `GetDataTypeNameAsync` reads the variable's DataType attribute first, resolves built-in ns=0 numeric types straight from the static map, and only consults/populates the cache for non-built-in types — so the expensive DisplayName browse is actually deduped across variables of the same type (the old per-variable keying never deduped anything).
- External behavior unchanged: same names returned, per-node errors still swallowed with the same warning log.

## Test plan
- [x] `dotnet build Opcilloscope.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test -c Release` — 613/613 passing (integration tests against the in-process server included)

---
Part of the v1 follow-up punch list (`docs/V1-REVIEW-FOLLOWUP.md`, item 5).

https://claude.ai/code/session_012Vopnd9vWkzELveHRgZhie

---
_Generated by [Claude Code](https://claude.ai/code/session_012Vopnd9vWkzELveHRgZhie)_