### PR TITLE
Harden OPC UA layer: reconnect races, handle allocation, interval/security wiring, status semantics

### DIFF
--- a/App/MainWindow.cs
+++ b/App/MainWindow.cs
@@ -1251,7 +1251,15 @@ License: MIT
                 // old server while (or after) the new connection is attempted.
                 await DisconnectAsync();
 
-                var connected = await _connectionManager.ConnectAsync(config.Server.EndpointUrl, config.Settings.PublishingIntervalMs, credentials);
+                // Honor the config's security and sampling settings (the connect dialog has
+                // no UI for these, so the config file is their only source).
+                var connected = await _connectionManager.ConnectAsync(
+                    config.Server.EndpointUrl,
+                    config.Settings.PublishingIntervalMs,
+                    credentials,
+                    config.Server.SecurityMode,
+                    config.Server.SecurityPolicy,
+                    config.Settings.SamplingIntervalMs);
 
                 if (connected)
                 {

--- a/OpcUa/ConnectionManager.cs
+++ b/OpcUa/ConnectionManager.cs
@@ -17,6 +17,11 @@ public sealed class ConnectionManager : IDisposable
     private bool _disposed;
     private int _isReconnecting;
 
+    // Intervals from the most recent ConnectAsync, so subscription restoration
+    // after a reconnect does not silently fall back to the defaults.
+    private int _publishingInterval = 250;
+    private int _samplingInterval = 250;
+
     // Stored event handler references for proper unsubscription
     private Action<Models.MonitoredNode>? _valueChangedHandler;
     private Action<Models.MonitoredNode>? _variableAddedHandler;
@@ -115,13 +120,15 @@ public sealed class ConnectionManager : IDisposable
     /// <param name="credentials">Authentication credentials (defaults to anonymous).</param>
     /// <param name="securityMode">Requested message security mode (e.g. None, Sign, SignAndEncrypt). When null/None, an unsecured endpoint is selected.</param>
     /// <param name="securityPolicy">Requested security policy URI or shorthand (e.g. Basic256Sha256). Honored when a matching endpoint exists.</param>
+    /// <param name="samplingInterval">Sampling interval in milliseconds for monitored items.</param>
     /// <returns>True if connection succeeded, false otherwise.</returns>
     public async Task<bool> ConnectAsync(
         string endpoint,
         int publishingInterval = 250,
         ConnectionCredentials? credentials = null,
         string? securityMode = null,
-        string? securityPolicy = null)
+        string? securityPolicy = null,
+        int samplingInterval = 250)
     {
         // Async teardown: the synchronous Disconnect() blocks on the OPC UA close
         // round-trip (up to the transport timeout against a dead server), which froze
@@ -130,6 +137,8 @@ public sealed class ConnectionManager : IDisposable
 
         _lastEndpoint = endpoint;
         _credentials = credentials ?? ConnectionCredentials.Anonymous;
+        _publishingInterval = publishingInterval;
+        _samplingInterval = samplingInterval;
         StateChanged?.Invoke(ConnectionState.Connecting);
 
         try
@@ -138,7 +147,7 @@ public sealed class ConnectionManager : IDisposable
 
             if (success)
             {
-                if (!await InitializeSubscriptionAsync(publishingInterval))
+                if (!await InitializeSubscriptionAsync())
                 {
                     // Without a subscription the session is useless for monitoring;
                     // fail the connect rather than reporting Connected.
@@ -271,9 +280,20 @@ public sealed class ConnectionManager : IDisposable
         if (!recreated)
         {
             _logger.Warning("Failed to recreate subscriptions - initializing fresh");
-            // Last resort: start fresh (will lose monitored nodes)
+            // Last resort: start fresh. The monitored nodes are gone, so tell the UI -
+            // otherwise their rows sit at "(reconnecting...)" forever with handles the
+            // new subscription manager knows nothing about.
+            var lostHandles = _subscriptionManager.MonitoredVariables
+                .Select(v => v.ClientHandle)
+                .ToList();
+
             DisposeSubscription();
             await InitializeSubscriptionAsync();
+
+            foreach (var handle in lostHandles)
+            {
+                VariableRemoved?.Invoke(handle);
+            }
         }
     }
 
@@ -313,10 +333,11 @@ public sealed class ConnectionManager : IDisposable
         return _client.WriteValueAsync(nodeId, value);
     }
 
-    private async Task<bool> InitializeSubscriptionAsync(int publishingInterval = 250)
+    private async Task<bool> InitializeSubscriptionAsync()
     {
         _subscriptionManager = new SubscriptionManager(_client, _logger);
-        _subscriptionManager.PublishingInterval = publishingInterval;
+        _subscriptionManager.PublishingInterval = _publishingInterval;
+        _subscriptionManager.SamplingInterval = _samplingInterval;
         var initialized = await _subscriptionManager.InitializeAsync();
 
         // Store handler references for proper unsubscription

--- a/OpcUa/Models/MonitoredNode.cs
+++ b/OpcUa/Models/MonitoredNode.cs
@@ -24,8 +24,11 @@ public class MonitoredNode
 
     public DateTime? Timestamp { get; set; }
     public uint StatusCode { get; set; }
-    public bool IsGood => StatusCode == 0; // StatusCode.Good = 0
-    public bool IsUncertain => (StatusCode & 0x40000000) != 0;
+    // OPC UA status severity lives in the top two bits: 00 = Good, 01 = Uncertain,
+    // 10 = Bad. Good codes with info bits set (e.g. GoodClamped 0x00300000) are
+    // still Good, so testing for == 0 would misclassify them.
+    public bool IsGood => (StatusCode & 0xC0000000) == 0;
+    public bool IsUncertain => (StatusCode & 0xC0000000) == 0x40000000;
     public bool IsBad => (StatusCode & 0x80000000) != 0;
     public DateTime LastChangeTime { get; set; } = DateTime.MinValue;
     public bool RecentlyChanged => (DateTime.Now - LastChangeTime).TotalMilliseconds < 500;
@@ -72,9 +75,9 @@ public class MonitoredNode
         get
         {
             if (StatusCode == 0) return "Good";
-            if ((StatusCode & 0x80000000) != 0) return $"Bad (0x{StatusCode:X8})";
-            if ((StatusCode & 0x40000000) != 0) return $"Uncertain (0x{StatusCode:X8})";
-            return $"0x{StatusCode:X8}";
+            if (IsBad) return $"Bad (0x{StatusCode:X8})";
+            if (IsUncertain) return $"Uncertain (0x{StatusCode:X8})";
+            return $"Good (0x{StatusCode:X8})";
         }
     }
 

--- a/OpcUa/OpcUaClientWrapper.cs
+++ b/OpcUa/OpcUaClientWrapper.cs
@@ -15,6 +15,7 @@ public class OpcUaClientWrapper : IDisposable
     private readonly Logger _logger;
     private string? _currentEndpoint;
     private CancellationTokenSource? _reconnectCts;
+    private readonly object _reconnectCtsLock = new();
     private bool _disposed;
     private ApplicationConfiguration? _appConfig;
     private ConfiguredEndpoint? _lastConfiguredEndpoint;
@@ -287,14 +288,22 @@ public class OpcUaClientWrapper : IDisposable
 
     /// <summary>
     /// Cancels and disposes the reconnect cancellation token source, if any.
+    /// Safe to race with <see cref="ReconnectAsync"/>: the field swap happens
+    /// under a lock, so two callers can never dispose the same instance twice.
     /// </summary>
     private void DisposeReconnectCts()
     {
-        if (_reconnectCts != null)
+        CancellationTokenSource? cts;
+        lock (_reconnectCtsLock)
         {
-            try { _reconnectCts.Cancel(); } catch (ObjectDisposedException) { }
-            _reconnectCts.Dispose();
+            cts = _reconnectCts;
             _reconnectCts = null;
+        }
+
+        if (cts != null)
+        {
+            try { cts.Cancel(); } catch (ObjectDisposedException) { }
+            cts.Dispose();
         }
     }
 
@@ -313,14 +322,23 @@ public class OpcUaClientWrapper : IDisposable
         }
 
         DisposeReconnectCts();
-        _reconnectCts = new CancellationTokenSource();
+
+        // Work with a local reference throughout: a concurrent Disconnect() can null
+        // and dispose the field at any time, so re-reading it mid-loop would NRE or
+        // touch a disposed CTS.
+        var cts = new CancellationTokenSource();
+        lock (_reconnectCtsLock)
+        {
+            _reconnectCts = cts;
+        }
+        var token = cts.Token;
 
         // Exponential backoff: 1s, 2s, 4s, 8s
         int[] delays = { 1000, 2000, 4000, 8000 };
 
         for (int attempt = 0; attempt < delays.Length; attempt++)
         {
-            if (_reconnectCts.Token.IsCancellationRequested)
+            if (token.IsCancellationRequested)
                 return false;
 
             _logger.Info($"Reconnection attempt {attempt + 1}/{delays.Length}...");
@@ -330,8 +348,8 @@ public class OpcUaClientWrapper : IDisposable
                 // Strategy 1: Try to reconnect the existing session (preserves subscriptions automatically)
                 if (_session != null)
                 {
-                    var reconnectResult = await TrySessionReconnectAsync();
-                    if (reconnectResult)
+                    var reconnectResult = await TrySessionReconnectAsync(token);
+                    if (reconnectResult && !token.IsCancellationRequested)
                     {
                         _logger.Info("Session reconnected successfully (subscriptions preserved)");
                         Connected?.Invoke();
@@ -340,9 +358,18 @@ public class OpcUaClientWrapper : IDisposable
                 }
 
                 // Strategy 2: Recreate session and transfer subscriptions
-                var recreateResult = await TryRecreateSessionAsync();
+                var recreateResult = await TryRecreateSessionAsync(token);
                 if (recreateResult)
                 {
+                    if (token.IsCancellationRequested)
+                    {
+                        // The user disconnected while the session was being recreated;
+                        // don't resurrect a connection they asked to close.
+                        _logger.Info("Reconnect cancelled after session recreation - closing the new session");
+                        await DisconnectAsync();
+                        return false;
+                    }
+
                     _logger.Info("Session recreated successfully (subscriptions transferred)");
                     Connected?.Invoke();
                     return true;
@@ -356,7 +383,7 @@ public class OpcUaClientWrapper : IDisposable
             // Wait before next attempt
             try
             {
-                await Task.Delay(delays[attempt], _reconnectCts.Token);
+                await Task.Delay(delays[attempt], token);
             }
             catch (OperationCanceledException)
             {
@@ -373,7 +400,7 @@ public class OpcUaClientWrapper : IDisposable
     /// Tries to reconnect the existing session using OPC UA Reconnect service.
     /// This preserves the session ID and all subscriptions automatically.
     /// </summary>
-    private async Task<bool> TrySessionReconnectAsync()
+    private async Task<bool> TrySessionReconnectAsync(CancellationToken cancellationToken)
     {
         if (_session == null)
             return false;
@@ -381,7 +408,7 @@ public class OpcUaClientWrapper : IDisposable
         try
         {
             _logger.Info("Attempting session reconnect...");
-            await _session.ReconnectAsync(_reconnectCts?.Token ?? CancellationToken.None);
+            await _session.ReconnectAsync(cancellationToken);
             return _session.Connected;
         }
         catch (ServiceResultException ex)
@@ -395,7 +422,7 @@ public class OpcUaClientWrapper : IDisposable
     /// Recreates the session and transfers existing subscriptions to it.
     /// Used when direct reconnect fails (e.g., session timed out on server).
     /// </summary>
-    private async Task<bool> TryRecreateSessionAsync()
+    private async Task<bool> TryRecreateSessionAsync(CancellationToken cancellationToken)
     {
         if (_lastConfiguredEndpoint == null || string.IsNullOrEmpty(_currentEndpoint))
             return false;
@@ -450,7 +477,7 @@ public class OpcUaClientWrapper : IDisposable
             {
                 if (subscriptionsToTransfer != null && subscriptionsToTransfer.Count > 0)
                 {
-                    var transferred = await TransferSubscriptionsAsync(subscriptionsToTransfer);
+                    var transferred = await TransferSubscriptionsAsync(subscriptionsToTransfer, cancellationToken);
                     _logger.Info($"Transferred {transferred} of {subscriptionsToTransfer.Count} subscription(s)");
                 }
             }
@@ -487,7 +514,7 @@ public class OpcUaClientWrapper : IDisposable
     /// <summary>
     /// Transfers subscriptions from a previous session to the current session.
     /// </summary>
-    private async Task<int> TransferSubscriptionsAsync(SubscriptionCollection subscriptions)
+    private async Task<int> TransferSubscriptionsAsync(SubscriptionCollection subscriptions, CancellationToken cancellationToken)
     {
         if (_session == null || subscriptions == null)
             return 0;
@@ -500,7 +527,7 @@ public class OpcUaClientWrapper : IDisposable
             var success = await _session.TransferSubscriptionsAsync(
                 subscriptions,
                 sendInitialValues: true,
-                _reconnectCts?.Token ?? CancellationToken.None);
+                cancellationToken);
 
             if (success)
             {
@@ -742,6 +769,14 @@ public class OpcUaClientWrapper : IDisposable
         }
 
         _logger.Info($"Selected endpoint: {selectedEndpoint.SecurityMode} / {selectedEndpoint.SecurityPolicyUri}");
+
+        if (_credentials.Type != AuthenticationType.Anonymous
+            && selectedEndpoint.SecurityMode == MessageSecurityMode.None)
+        {
+            _logger.Warning(
+                "Credentials will be sent over an UNENCRYPTED channel: the selected endpoint uses SecurityMode=None. " +
+                "Anyone on the network can read the username and password. Prefer a server endpoint with Sign or SignAndEncrypt.");
+        }
 
         // Update the endpoint URL to use the requested host if different
         // (handles cases where server returns localhost but we connected via IP/hostname)

--- a/OpcUa/SubscriptionManager.cs
+++ b/OpcUa/SubscriptionManager.cs
@@ -21,6 +21,7 @@ public class SubscriptionManager : IDisposable, IAsyncDisposable
     private readonly Dictionary<uint, uint> _opcHandleToClientHandle = new();
     private uint _nextClientHandle = 1;
     private int _publishingInterval = 250;
+    private int _samplingInterval = 250;
     private bool _isInitialized;
     private readonly object _lock = new();
 
@@ -43,6 +44,16 @@ public class SubscriptionManager : IDisposable, IAsyncDisposable
     {
         get => _publishingInterval;
         set => _publishingInterval = Math.Max(100, Math.Min(10000, value));
+    }
+
+    /// <summary>
+    /// Sampling interval in milliseconds applied to monitored items.
+    /// 0 requests the server's fastest practical rate.
+    /// </summary>
+    public int SamplingInterval
+    {
+        get => _samplingInterval;
+        set => _samplingInterval = Math.Max(0, Math.Min(60000, value));
     }
 
     public IReadOnlyCollection<MonitoredNode> MonitoredVariables
@@ -107,6 +118,7 @@ public class SubscriptionManager : IDisposable, IAsyncDisposable
             return null;
         }
 
+        uint clientHandle;
         lock (_lock)
         {
             // Check if already monitoring this node
@@ -115,11 +127,14 @@ public class SubscriptionManager : IDisposable, IAsyncDisposable
                 _logger.Warning($"Node {displayName} is already being monitored");
                 return null;
             }
+
+            // Allocate the handle under the lock: it keys three dictionaries, and an
+            // unsynchronized increment lets two concurrent adds collide on one handle.
+            clientHandle = _nextClientHandle++;
         }
 
         try
         {
-            var clientHandle = _nextClientHandle++;
 
             // Create OPC UA monitored item
             var monitoredItem = new MonitoredItem(_subscription.DefaultItem)
@@ -127,7 +142,7 @@ public class SubscriptionManager : IDisposable, IAsyncDisposable
                 DisplayName = displayName,
                 StartNodeId = nodeId,
                 AttributeId = Attributes.Value,
-                SamplingInterval = 250,
+                SamplingInterval = _samplingInterval,
                 QueueSize = 10,
                 DiscardOldest = true
             };
@@ -589,7 +604,7 @@ public class SubscriptionManager : IDisposable, IAsyncDisposable
                     DisplayName = displayName,
                     StartNodeId = nodeId,
                     AttributeId = Attributes.Value,
-                    SamplingInterval = 250,
+                    SamplingInterval = _samplingInterval,
                     QueueSize = 10,
                     DiscardOldest = true
                 };

--- a/Tests/Opcilloscope.Tests/OpcUa/Models/MonitoredNodeTests.cs
+++ b/Tests/Opcilloscope.Tests/OpcUa/Models/MonitoredNodeTests.cs
@@ -23,6 +23,38 @@ public class MonitoredNodeTests
     }
 
     [Fact]
+    public void MonitoredNode_IsGood_ReturnsTrueForGoodWithInfoBits()
+    {
+        // GoodClamped (0x00300000): Good severity with informational sub-status bits.
+        var node = new MonitoredNode
+        {
+            NodeId = new NodeId(1000),
+            DisplayName = "Test",
+            StatusCode = 0x00300000
+        };
+
+        // Assert
+        Assert.True(node.IsGood);
+        Assert.False(node.IsUncertain);
+        Assert.False(node.IsBad);
+    }
+
+    [Fact]
+    public void MonitoredNode_StatusString_ReturnsGoodWithCodeForGoodWithInfoBits()
+    {
+        var node = new MonitoredNode
+        {
+            NodeId = new NodeId(1000),
+            DisplayName = "Test",
+            StatusCode = 0x00300000 // GoodClamped
+        };
+
+        // Assert
+        Assert.StartsWith("Good", node.StatusString);
+        Assert.Contains("0x00300000", node.StatusString);
+    }
+
+    [Fact]
     public void MonitoredNode_IsBad_ReturnsTrueWhenBadBitSet()
     {
         // Arrange

--- a/Tests/Opcilloscope.Tests/OpcUa/SubscriptionManagerTests.cs
+++ b/Tests/Opcilloscope.Tests/OpcUa/SubscriptionManagerTests.cs
@@ -6,6 +6,23 @@ namespace Opcilloscope.Tests.OpcUa;
 
 public class SubscriptionManagerTests
 {
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(250, 250)]
+    [InlineData(5000, 5000)]
+    [InlineData(-1, 0)]
+    [InlineData(100000, 60000)]
+    public void SamplingInterval_ClampsToValidRange(int requested, int expected)
+    {
+        var manager = new SubscriptionManager(
+            new global::Opcilloscope.OpcUa.OpcUaClientWrapper(),
+            new global::Opcilloscope.Utilities.Logger());
+
+        manager.SamplingInterval = requested;
+
+        Assert.Equal(expected, manager.SamplingInterval);
+    }
+
     [Fact]
     public void FormatValue_ReturnsNull_WhenValueIsNull()
     {


### PR DESCRIPTION
## Summary
> **Stacked on #167** (`fix/connection-lifecycle-2`) — review/merge that first; this PR will retarget to `main` once it merges.

Hardens the OPC UA layer per the v1.0 follow-up review (`docs/V1-REVIEW-FOLLOWUP.md`, items 10–12 and the interval/security/status lows):

- **Reconnect/disconnect races closed:** `ReconnectAsync` now works against a locally captured `CancellationTokenSource`; the field swap in `DisposeReconnectCts` happens under a lock (no more double-dispose/NRE TOCTOU with a concurrent `Disconnect`), and if the user disconnects while a session recreate is in flight, the freshly created session is closed instead of living on as a ghost connection behind a "Disconnected" UI.
- **Client-handle allocation race:** `AddNodeAsync` allocates `_nextClientHandle` inside the dedup lock — the unsynchronized `++` let two concurrent adds of *different* nodes collide on one handle and silently overwrite each other's entries in the three handle-keyed dictionaries (same TOCTOU class PR #158 closed for the NodeId dedup, one line away).
- **No more stranded rows:** the last-resort restore path (recreate failed → fresh subscription) now raises `VariableRemoved` for every lost node, so the UI no longer shows rows stuck at "(reconnecting...)" with handles the new subscription manager knows nothing about.
- **`settings.samplingIntervalMs` is finally honored** — it was a documented no-op (hardcoded 250 in both `AddNodeAsync` and `RecreateSubscriptionsAsync`). `SubscriptionManager` gains a clamped `SamplingInterval` property; `ConnectionManager` stores both intervals from `ConnectAsync` and reuses them when subscriptions are restored after reconnect (restores previously fell back to the 250 ms defaults too).
- **Config security settings wired** (closes the declared loose end from PR #160): `MainWindow.LoadConfigurationAsync` now passes `securityMode`/`securityPolicy`/`samplingIntervalMs` from the config file to `ConnectAsync`. A warning is logged when credentials are about to be sent over a `SecurityMode=None` endpoint (the other declared loose end).
- **Status semantics:** `MonitoredNode` treats Good-with-info-bits codes (e.g. `GoodClamped` 0x00300000) as Good — severity is the top two bits, not `== 0` — so such values no longer render as raw hex with non-good row styling.

## Test plan
- [x] `dotnet build Opcilloscope.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test -c Release` — 620/620 passing (7 new tests: Good-substatus semantics, SamplingInterval clamping)
- [ ] Manual: load a config with `samplingIntervalMs: 5000` → server diagnostics show 5000 ms sampling; disconnect during an auto-reconnect → no ghost session

---
Part of the v1 follow-up punch list (`docs/V1-REVIEW-FOLLOWUP.md`, items 10–12 + lows).

https://claude.ai/code/session_012Vopnd9vWkzELveHRgZhie

---
_Generated by [Claude Code](https://claude.ai/code/session_012Vopnd9vWkzELveHRgZhie)_