### PR TITLE
Harden config persistence: preserve disabled nodes, tolerate JSON nulls, reject future versions

### DIFF
--- a/Configuration/ConfigurationService.cs
+++ b/Configuration/ConfigurationService.cs
@@ -69,9 +69,11 @@ public class ConfigurationService
     private const string CurrentConfigVersion = "1.0";
 
     /// <summary>
-    /// The major component of <see cref="CurrentConfigVersion"/>.
+    /// The major component of <see cref="CurrentConfigVersion"/>, derived from it
+    /// so the two cannot drift apart when the version is bumped.
     /// </summary>
-    private const int CurrentConfigMajorVersion = 1;
+    private static readonly int CurrentConfigMajorVersion =
+        int.Parse(CurrentConfigVersion.Split('.')[0]);
 
     /// <summary>
     /// Loads a configuration from the specified file path.

--- a/Configuration/ConfigurationService.cs
+++ b/Configuration/ConfigurationService.cs
@@ -64,6 +64,16 @@ public class ConfigurationService
     private const long MaxConfigFileSizeBytes = 1024 * 1024;
 
     /// <summary>
+    /// The configuration file format version written by this build.
+    /// </summary>
+    private const string CurrentConfigVersion = "1.0";
+
+    /// <summary>
+    /// The major component of <see cref="CurrentConfigVersion"/>.
+    /// </summary>
+    private const int CurrentConfigMajorVersion = 1;
+
+    /// <summary>
     /// Loads a configuration from the specified file path.
     /// </summary>
     /// <param name="filePath">Path to the configuration file.</param>
@@ -83,6 +93,10 @@ public class ConfigurationService
         var config = JsonSerializer.Deserialize(json, OpcilloscopeJsonContext.Default.OpcilloscopeConfig)
             ?? throw new InvalidDataException("Invalid configuration file");
 
+        // Normalize explicit JSON nulls ("settings": null, etc.) so they behave
+        // like absent sections instead of crashing later code with null references.
+        NormalizeConfig(config);
+
         // Handle version migrations if needed
         config = MigrateIfNeeded(config);
 
@@ -98,12 +112,74 @@ public class ConfigurationService
     }
 
     /// <summary>
+    /// Replaces sections deserialized as explicit JSON nulls with their default
+    /// instances, matching the behavior of absent fields. System.Text.Json assigns
+    /// null over the property initializers when the file contains e.g. "settings": null.
+    /// </summary>
+    /// <param name="config">The configuration to normalize.</param>
+    private static void NormalizeConfig(OpcilloscopeConfig config)
+    {
+        if (string.IsNullOrEmpty(config.Version))
+        {
+            config.Version = CurrentConfigVersion;
+        }
+
+        if (config.Server is null)
+        {
+            config.Server = new ServerConfig();
+        }
+
+        if (config.Server.Authentication is null)
+        {
+            config.Server.Authentication = new AuthenticationConfig();
+        }
+
+        if (config.Settings is null)
+        {
+            config.Settings = new SubscriptionSettings();
+        }
+
+        if (config.MonitoredNodes is null)
+        {
+            config.MonitoredNodes = new List<MonitoredNodeConfig>();
+        }
+
+        if (config.Metadata is null)
+        {
+            config.Metadata = new ConfigMetadata();
+        }
+    }
+
+    /// <summary>
     /// Validates a configuration object for common issues.
     /// </summary>
     /// <param name="config">The configuration to validate.</param>
     /// <exception cref="InvalidDataException">Thrown if validation fails.</exception>
     private void ValidateConfiguration(OpcilloscopeConfig config)
     {
+        // Backstop null checks with meaningful messages; LoadAsync normalizes
+        // explicit JSON nulls before validation, but callers constructing
+        // configurations programmatically may still pass null sections.
+        if (config.Server is null)
+        {
+            throw new InvalidDataException("Configuration is missing the 'server' section.");
+        }
+
+        if (config.Settings is null)
+        {
+            throw new InvalidDataException("Configuration is missing the 'settings' section.");
+        }
+
+        if (config.MonitoredNodes is null)
+        {
+            throw new InvalidDataException("Configuration is missing the 'monitoredNodes' section.");
+        }
+
+        if (config.Metadata is null)
+        {
+            throw new InvalidDataException("Configuration is missing the 'metadata' section.");
+        }
+
         // Validate publishing interval
         if (config.Settings.PublishingIntervalMs < 0)
         {
@@ -204,16 +280,39 @@ public class ConfigurationService
             settings.QueueSize = sourceSettings.QueueSize;
         }
 
+        var monitoredNodes = monitoredVariables.Select(m => new MonitoredNodeConfig
+        {
+            NodeId = m.NodeId.ToString(),
+            DisplayName = m.DisplayName,
+            Enabled = true
+        }).ToList();
+
+        // Preserve disabled entries from the loaded configuration so a load/save
+        // round-trip does not silently delete them (only enabled nodes are
+        // subscribed on load, so they never appear in the live list). Entries the
+        // user actively unsubscribed were enabled in the loaded config and are
+        // intentionally dropped.
+        if (_loadedConfig?.MonitoredNodes is not null)
+        {
+            var liveNodeIds = monitoredNodes
+                .Select(n => n.NodeId)
+                .ToHashSet(StringComparer.Ordinal);
+
+            monitoredNodes.AddRange(_loadedConfig.MonitoredNodes
+                .Where(n => !n.Enabled && !liveNodeIds.Contains(n.NodeId))
+                .Select(n => new MonitoredNodeConfig
+                {
+                    NodeId = n.NodeId,
+                    DisplayName = n.DisplayName,
+                    Enabled = false
+                }));
+        }
+
         return new OpcilloscopeConfig
         {
             Server = server,
             Settings = settings,
-            MonitoredNodes = monitoredVariables.Select(m => new MonitoredNodeConfig
-            {
-                NodeId = m.NodeId.ToString(),
-                DisplayName = m.DisplayName,
-                Enabled = true
-            }).ToList(),
+            MonitoredNodes = monitoredNodes,
             Metadata = existingMetadata ?? new ConfigMetadata
             {
                 CreatedAt = DateTime.UtcNow,
@@ -248,8 +347,25 @@ public class ConfigurationService
     /// <summary>
     /// Handles version migrations for configuration files.
     /// </summary>
+    /// <exception cref="InvalidDataException">
+    /// Thrown if the configuration was created by a newer major version of opcilloscope.
+    /// </exception>
     private OpcilloscopeConfig MigrateIfNeeded(OpcilloscopeConfig config)
     {
+        // Reject files from a newer major version: unknown fields are dropped on
+        // deserialization, so loading and re-saving would silently destroy data.
+        // Null, empty, or unparseable versions are treated as the current version.
+        var version = config.Version;
+        if (!string.IsNullOrWhiteSpace(version)
+            && int.TryParse(version.Split('.')[0], out var major)
+            && major > CurrentConfigMajorVersion)
+        {
+            throw new InvalidDataException(
+                $"Configuration file version '{version}' was created by a newer version of opcilloscope. " +
+                $"This build supports configuration version {CurrentConfigVersion}. " +
+                "Please upgrade opcilloscope to open this file.");
+        }
+
         // Future: handle "1.0" -> "1.1" migrations, etc.
         // For now, just return the config as-is
         return config;

--- a/Tests/Opcilloscope.Tests/Configuration/ConfigurationServiceTests.cs
+++ b/Tests/Opcilloscope.Tests/Configuration/ConfigurationServiceTests.cs
@@ -814,6 +814,268 @@ public class ConfigurationServiceTests : IDisposable
 
     #endregion
 
+    #region Disabled Node Preservation Tests
+
+    [Fact]
+    public async Task LoadThenCaptureCurrentState_PreservesDisabledNodes()
+    {
+        // Arrange: a config with both enabled and disabled monitored nodes.
+        var config = CreateTestConfig();
+        config.MonitoredNodes = new List<MonitoredNodeConfig>
+        {
+            new() { NodeId = "ns=2;s=Counter", DisplayName = "Counter", Enabled = true },
+            new() { NodeId = "ns=2;s=Spare", DisplayName = "Spare", Enabled = false }
+        };
+        var filePath = Path.Combine(_tempDir, "disabled.cfg");
+        await _service.SaveAsync(config, filePath);
+        await _service.LoadAsync(filePath);
+
+        // Act: capture state with only the enabled node live (matching how
+        // MainWindow only subscribes to enabled nodes on load).
+        var captured = _service.CaptureCurrentState(
+            "opc.tcp://localhost:4840",
+            1000,
+            new List<MonitoredNode>
+            {
+                new() { NodeId = new NodeId("Counter", 2), DisplayName = "Counter" }
+            });
+
+        // Assert: the disabled entry survives the round-trip with Enabled = false.
+        Assert.Equal(2, captured.MonitoredNodes.Count);
+        var live = captured.MonitoredNodes.Single(n => n.NodeId == "ns=2;s=Counter");
+        Assert.True(live.Enabled);
+        var disabled = captured.MonitoredNodes.Single(n => n.NodeId == "ns=2;s=Spare");
+        Assert.False(disabled.Enabled);
+        Assert.Equal("Spare", disabled.DisplayName);
+    }
+
+    [Fact]
+    public async Task LoadThenCaptureCurrentState_DropsUnsubscribedEnabledNodes()
+    {
+        // Arrange: two enabled nodes and one disabled node in the loaded config.
+        var config = CreateTestConfig();
+        config.MonitoredNodes = new List<MonitoredNodeConfig>
+        {
+            new() { NodeId = "ns=2;s=Counter", DisplayName = "Counter", Enabled = true },
+            new() { NodeId = "ns=2;s=SineWave", DisplayName = "SineWave", Enabled = true },
+            new() { NodeId = "ns=2;s=Spare", DisplayName = "Spare", Enabled = false }
+        };
+        var filePath = Path.Combine(_tempDir, "unsubscribed.cfg");
+        await _service.SaveAsync(config, filePath);
+        await _service.LoadAsync(filePath);
+
+        // Act: the user unsubscribed SineWave, so only Counter is live.
+        var captured = _service.CaptureCurrentState(
+            "opc.tcp://localhost:4840",
+            1000,
+            new List<MonitoredNode>
+            {
+                new() { NodeId = new NodeId("Counter", 2), DisplayName = "Counter" }
+            });
+
+        // Assert: the actively unsubscribed (previously enabled) node is dropped,
+        // while the disabled node is preserved.
+        Assert.Equal(2, captured.MonitoredNodes.Count);
+        Assert.DoesNotContain(captured.MonitoredNodes, n => n.NodeId == "ns=2;s=SineWave");
+        Assert.Contains(captured.MonitoredNodes, n => n.NodeId == "ns=2;s=Spare" && !n.Enabled);
+    }
+
+    [Fact]
+    public async Task LoadThenCaptureCurrentState_DisabledNodeResubscribed_SavedOnceAsEnabled()
+    {
+        // Arrange: a disabled node in the loaded config.
+        var config = CreateTestConfig();
+        config.MonitoredNodes = new List<MonitoredNodeConfig>
+        {
+            new() { NodeId = "ns=2;s=Counter", DisplayName = "Counter", Enabled = false }
+        };
+        var filePath = Path.Combine(_tempDir, "resubscribed.cfg");
+        await _service.SaveAsync(config, filePath);
+        await _service.LoadAsync(filePath);
+
+        // Act: the user manually subscribed to the same node, making it live.
+        var captured = _service.CaptureCurrentState(
+            "opc.tcp://localhost:4840",
+            1000,
+            new List<MonitoredNode>
+            {
+                new() { NodeId = new NodeId("Counter", 2), DisplayName = "Counter" }
+            });
+
+        // Assert: no duplicate entry; the live (enabled) entry wins.
+        var entry = Assert.Single(captured.MonitoredNodes);
+        Assert.Equal("ns=2;s=Counter", entry.NodeId);
+        Assert.True(entry.Enabled);
+    }
+
+    #endregion
+
+    #region Null Section Handling Tests
+
+    [Theory]
+    [InlineData("server")]
+    [InlineData("settings")]
+    [InlineData("monitoredNodes")]
+    [InlineData("metadata")]
+    public async Task LoadAsync_NullSection_LoadsWithDefaults(string nullSection)
+    {
+        // Arrange: explicit JSON null overwrites the property initializer,
+        // which previously caused a NullReferenceException during validation.
+        var filePath = Path.Combine(_tempDir, $"null-{nullSection}.cfg");
+        var sections = new Dictionary<string, string>
+        {
+            ["server"] = """{ "endpointUrl": "opc.tcp://localhost:4840" }""",
+            ["settings"] = """{ "publishingIntervalMs": 1000 }""",
+            ["monitoredNodes"] = "[]",
+            ["metadata"] = "{}"
+        };
+        sections[nullSection] = "null";
+        var json = $$"""
+        {
+            "version": "1.0",
+            "server": {{sections["server"]}},
+            "settings": {{sections["settings"]}},
+            "monitoredNodes": {{sections["monitoredNodes"]}},
+            "metadata": {{sections["metadata"]}}
+        }
+        """;
+        await File.WriteAllTextAsync(filePath, json);
+
+        // Act
+        var loaded = await _service.LoadAsync(filePath);
+
+        // Assert: the null section was replaced with its default instance.
+        Assert.NotNull(loaded.Server);
+        Assert.NotNull(loaded.Server.Authentication);
+        Assert.NotNull(loaded.Settings);
+        Assert.NotNull(loaded.MonitoredNodes);
+        Assert.NotNull(loaded.Metadata);
+    }
+
+    [Fact]
+    public async Task LoadAsync_NullAuthentication_LoadsWithDefaults()
+    {
+        // Arrange
+        var filePath = Path.Combine(_tempDir, "null-auth.cfg");
+        var json = """
+        {
+            "version": "1.0",
+            "server": { "endpointUrl": "opc.tcp://localhost:4840", "authentication": null },
+            "settings": { "publishingIntervalMs": 1000 },
+            "monitoredNodes": [],
+            "metadata": {}
+        }
+        """;
+        await File.WriteAllTextAsync(filePath, json);
+
+        // Act
+        var loaded = await _service.LoadAsync(filePath);
+
+        // Assert
+        Assert.NotNull(loaded.Server.Authentication);
+        Assert.Equal("Anonymous", loaded.Server.Authentication.Type);
+    }
+
+    [Fact]
+    public async Task LoadAsync_NullVersion_DefaultsToCurrentVersion()
+    {
+        // Arrange
+        var filePath = Path.Combine(_tempDir, "null-version.cfg");
+        var json = """
+        {
+            "version": null,
+            "server": { "endpointUrl": "opc.tcp://localhost:4840" },
+            "settings": { "publishingIntervalMs": 1000 },
+            "monitoredNodes": [],
+            "metadata": {}
+        }
+        """;
+        await File.WriteAllTextAsync(filePath, json);
+
+        // Act
+        var loaded = await _service.LoadAsync(filePath);
+
+        // Assert
+        Assert.Equal("1.0", loaded.Version);
+    }
+
+    #endregion
+
+    #region Version Check Tests
+
+    [Fact]
+    public async Task LoadAsync_FutureMajorVersion_ThrowsInvalidDataException()
+    {
+        // Arrange
+        var filePath = Path.Combine(_tempDir, "future.cfg");
+        var json = """
+        {
+            "version": "2.0",
+            "server": { "endpointUrl": "opc.tcp://localhost:4840" },
+            "settings": { "publishingIntervalMs": 1000 },
+            "monitoredNodes": [],
+            "metadata": {}
+        }
+        """;
+        await File.WriteAllTextAsync(filePath, json);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<InvalidDataException>(
+            () => _service.LoadAsync(filePath));
+        Assert.Contains("newer version of opcilloscope", ex.Message);
+        Assert.Contains("2.0", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("\"1.0\"")]
+    [InlineData("\"1.5\"")]
+    [InlineData("\"not-a-version\"")]
+    public async Task LoadAsync_SameMajorOrUnparseableVersion_Loads(string versionJson)
+    {
+        // Arrange
+        var filePath = Path.Combine(_tempDir, $"version-{Guid.NewGuid():N}.cfg");
+        var json = $$"""
+        {
+            "version": {{versionJson}},
+            "server": { "endpointUrl": "opc.tcp://localhost:4840" },
+            "settings": { "publishingIntervalMs": 1000 },
+            "monitoredNodes": [],
+            "metadata": {}
+        }
+        """;
+        await File.WriteAllTextAsync(filePath, json);
+
+        // Act
+        var loaded = await _service.LoadAsync(filePath);
+
+        // Assert
+        Assert.NotNull(loaded);
+    }
+
+    [Fact]
+    public async Task LoadAsync_MissingVersion_Loads()
+    {
+        // Arrange
+        var filePath = Path.Combine(_tempDir, "no-version.cfg");
+        var json = """
+        {
+            "server": { "endpointUrl": "opc.tcp://localhost:4840" },
+            "settings": { "publishingIntervalMs": 1000 },
+            "monitoredNodes": [],
+            "metadata": {}
+        }
+        """;
+        await File.WriteAllTextAsync(filePath, json);
+
+        // Act
+        var loaded = await _service.LoadAsync(filePath);
+
+        // Assert
+        Assert.Equal("1.0", loaded.Version);
+    }
+
+    #endregion
+
     private static OpcilloscopeConfig CreateTestConfig()
     {
         return new OpcilloscopeConfig


### PR DESCRIPTION
## Summary
Hardens configuration load/save per the v1.0 follow-up review (`docs/V1-REVIEW-FOLLOWUP.md`, item 8 + the JSON-null and version-check lows). `ConfigurationService` only — no UI changes, merges cleanly alongside the in-flight MainWindow PRs.

- **Disabled nodes survive a load → save round-trip.** `CaptureCurrentState` rebuilt `monitoredNodes` solely from live subscriptions with `Enabled = true` hard-coded, so a config containing `"enabled": false` entries lost them permanently on the next Ctrl+S (the same data-loss class PR #159 fixed for the security fields). It now appends the loaded config's disabled entries whose NodeId isn't already live; entries the user actively unsubscribed are still dropped, and a re-subscribed disabled entry appears once, enabled.
- **Explicit JSON nulls load cleanly.** `"settings": null` (or server/monitoredNodes/metadata/authentication) previously surfaced as "Object reference not set to an instance of an object". A new normalization pass in `LoadAsync` replaces null sections with their defaults — consistent with how absent fields behave — and `ValidateConfiguration` keeps backstop checks with meaningful messages.
- **Version check.** `MigrateIfNeeded` was a no-op; a future-version config loaded silently, dropped unknown fields, and was rewritten as 1.0 minus the data. Now: same/older major accepted, null/unparseable treated as current, higher major (e.g. "2.0") rejected with a clear "created by a newer version of opcilloscope — please upgrade" error.

## Test plan
- [x] `dotnet build Opcilloscope.sln -c Release` — 0 warnings, 0 errors
- [x] Configuration tests: 76/76 passing (14 new cases: disabled-node preservation/drop/dedupe, every null section, future-major rejection, version acceptance matrix)
- [ ] Full suite in CI (the sandbox the branch was built in can't bind the integration test server's sockets; all non-integration tests pass locally)

---
Part of the v1 follow-up punch list (`docs/V1-REVIEW-FOLLOWUP.md`, item 8 + lows).

https://claude.ai/code/session_012Vopnd9vWkzELveHRgZhie

---
_Generated by [Claude Code](https://claude.ai/code/session_012Vopnd9vWkzELveHRgZhie)_