### PR TITLE
Release hygiene: checksums, test gate, no PDBs, correct ICU/macOS/uninstall guidance

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,10 @@ on:
 
 jobs:
   claude-review:
+    # Skip fork PRs: secrets.CLAUDE_CODE_OAUTH_TOKEN is not available to forks,
+    # so the job would always fail with a red X on external contributions.
+    if: github.event.pull_request.head.repo.fork == false
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,29 @@ permissions:
   contents: write
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # MinVer needs the full commit history (and tags) to compute versions.
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Test
+        run: dotnet test -c Release --verbosity normal
+
   build:
+    needs: test
     strategy:
       matrix:
         include:
@@ -55,7 +77,7 @@ jobs:
 
       - name: Publish
         run: |
-          dotnet publish Opcilloscope.csproj -c Release -r ${{ matrix.rid }} -o ./publish
+          dotnet publish Opcilloscope.csproj -c Release -r ${{ matrix.rid }} -o ./publish -p:DebugType=none
 
       - name: Smoke test published binary (Linux/macOS)
         if: matrix.smoke && runner.os != 'Windows'
@@ -120,12 +142,22 @@ jobs:
       - name: Display structure
         run: ls -R artifacts
 
+      - name: Collect release assets
+        run: |
+          mkdir -p release-assets
+          find artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' \) -exec cp {} release-assets/ \;
+          ls -l release-assets
+
+      - name: Generate SHA256SUMS
+        run: |
+          cd release-assets
+          sha256sum * > SHA256SUMS
+          cat SHA256SUMS
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
-          files: |
-            artifacts/**/*.tar.gz
-            artifacts/**/*.zip
+          files: release-assets/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build outputs
 bin/
 obj/
+publish/
 
 # IDE
 .vs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Usage: opcilloscope [options] [file]
 
 Options:
   -f, --config <file>   Load configuration file (.cfg, .opcilloscope, or .json)
+      --insecure        Accept untrusted server certificates (development only)
   -h, --help            Show help message
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -101,25 +101,14 @@ irm https://raw.githubusercontent.com/SquareWaveSystems/opcilloscope/main/instal
 
 Or grab a binary from [GitHub Releases](https://github.com/SquareWaveSystems/opcilloscope/releases).
 
+> **macOS note:** the binaries are unsigned, so archives downloaded with a browser are
+> quarantined by Gatekeeper. Either use the curl installer above, or clear the
+> quarantine attribute after extracting: `xattr -d com.apple.quarantine <binary>`.
+
 Then run:
 ```bash
 opcilloscope
 ```
-
-<details>
-<summary>Linux dependency: ICU libraries</summary>
-
-opcilloscope requires ICU libraries at runtime for globalization support.
-
-```bash
-# Debian 13 / Ubuntu 24.04+
-sudo apt install libicu72       # or: sudo apt install libicu-dev
-
-# Fedora / RHEL
-sudo dnf install libicu
-```
-
-</details>
 
 <details>
 <summary>Uninstall</summary>

--- a/install.ps1
+++ b/install.ps1
@@ -58,6 +58,33 @@ function Install-Opcilloscope {
         # Download
         Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath -UseBasicParsing
 
+        # Verify the archive against the SHA256SUMS published with the release.
+        # Degrades gracefully (warning only) when SHA256SUMS is unavailable (older releases).
+        $archiveName = "opcilloscope-$platform.zip"
+        $sumsUrl = "https://github.com/$Repo/releases/download/$version/SHA256SUMS"
+        $sumsPath = Join-Path $tempDir "SHA256SUMS"
+        $haveSums = $true
+        try {
+            Invoke-WebRequest -Uri $sumsUrl -OutFile $sumsPath -UseBasicParsing
+        } catch {
+            $haveSums = $false
+            Write-Warn "SHA256SUMS not found for $version (older release?). Skipping checksum verification."
+        }
+        if ($haveSums) {
+            Write-Info "Verifying checksum..."
+            $entry = Get-Content $sumsPath | Where-Object { $_ -match ("\s" + [regex]::Escape($archiveName) + "$") } | Select-Object -First 1
+            if (-not $entry) {
+                Write-Warn "No checksum entry for $archiveName in SHA256SUMS. Skipping checksum verification."
+            } else {
+                $expected = ($entry -split '\s+')[0].ToLowerInvariant()
+                $actual = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash.ToLowerInvariant()
+                if ($actual -ne $expected) {
+                    Write-Err "Checksum mismatch for ${archiveName}. Expected $expected but got $actual. The download may be corrupted or tampered with. Aborting."
+                }
+                Write-Info "Checksum verified (SHA-256)."
+            }
+        }
+
         Write-Info "Extracting..."
         Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
 

--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,43 @@ get_latest_version() {
         sed -E 's/.*"([^"]+)".*/\1/'
 }
 
+# Verify the downloaded archive against the SHA256SUMS published with the release.
+# Degrades gracefully (warning only) when SHA256SUMS is unavailable (older releases).
+verify_checksum() {
+    local version="$1" archive_name="$2" archive_path="$3" tmp_dir="$4"
+    local sums_url="https://github.com/${REPO}/releases/download/${version}/SHA256SUMS"
+    local expected actual
+
+    if ! curl -fsSL "$sums_url" -o "${tmp_dir}/SHA256SUMS" 2>/dev/null; then
+        warn "SHA256SUMS not found for ${version} (older release?). Skipping checksum verification."
+        return 0
+    fi
+
+    expected=$(grep " ${archive_name}\$" "${tmp_dir}/SHA256SUMS" | awk '{print $1}')
+    if [ -z "$expected" ]; then
+        warn "No checksum entry for ${archive_name} in SHA256SUMS. Skipping checksum verification."
+        return 0
+    fi
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$archive_path" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$archive_path" | awk '{print $1}')
+    else
+        warn "Neither sha256sum nor shasum is available. Skipping checksum verification."
+        return 0
+    fi
+
+    if [ "$actual" != "$expected" ]; then
+        echo ""
+        echo "  Expected: ${expected}"
+        echo "  Actual:   ${actual}"
+        error "Checksum mismatch for ${archive_name}. The download may be corrupted or tampered with. Aborting."
+    fi
+
+    info "Checksum verified (SHA-256)."
+}
+
 # Download and install
 install() {
     local platform version download_url tmp_dir
@@ -67,6 +104,9 @@ install() {
     if ! curl -fsSL "$download_url" -o "${tmp_dir}/opcilloscope.tar.gz"; then
         error "Download failed. Check if the release exists for platform: ${platform}"
     fi
+
+    info "Verifying checksum..."
+    verify_checksum "$version" "opcilloscope-${platform}.tar.gz" "${tmp_dir}/opcilloscope.tar.gz" "$tmp_dir"
 
     info "Extracting..."
     tar -xzf "${tmp_dir}/opcilloscope.tar.gz" -C "${tmp_dir}"
@@ -121,25 +161,6 @@ main() {
     # Check for required commands
     command -v curl >/dev/null 2>&1 || error "curl is required but not installed"
     command -v tar >/dev/null 2>&1 || error "tar is required but not installed"
-
-    # Check for ICU libraries (required at runtime by .NET for globalization)
-    if [ "$(uname -s)" = "Linux" ]; then
-        local icu_found=false
-        if command -v ldconfig >/dev/null 2>&1; then
-            ldconfig -p 2>/dev/null | grep -q libicu && icu_found=true
-        elif compgen -G '/usr/lib/*/libicu*.so*' >/dev/null 2>&1 \
-          || compgen -G '/usr/lib/libicu*.so*' >/dev/null 2>&1 \
-          || compgen -G '/usr/lib64/libicu*.so*' >/dev/null 2>&1; then
-            icu_found=true
-        fi
-        if [ "$icu_found" = false ]; then
-            warn "ICU libraries not found. opcilloscope requires libicu at runtime."
-            echo "  Install with:"
-            echo "    Debian/Ubuntu: sudo apt install libicu72  (or libicu-dev)"
-            echo "    Fedora/RHEL:   sudo dnf install libicu"
-            echo ""
-        fi
-    fi
 
     install
 }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -6,6 +6,7 @@ set -e
 
 INSTALL_DIR="${OPCILLOSCOPE_INSTALL_DIR:-$HOME/.local/bin}"
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/opcilloscope"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/opcilloscope"
 
 # Colors
 RED='\033[0;31m'
@@ -54,6 +55,26 @@ uninstall() {
             info "Removed config directory: ${CONFIG_DIR}"
         else
             info "Kept config directory: ${CONFIG_DIR}"
+        fi
+    fi
+
+    # Remove data directory (OPC UA certificate stores)
+    if [ -d "$DATA_DIR" ]; then
+        echo ""
+        echo -n "Remove OPC UA certificates directory ${DATA_DIR}? [y/N] "
+        # When piped from curl, stdin is the script itself, so default to no
+        if [ -t 0 ]; then
+            read -r answer
+        else
+            answer="n"
+            echo "(skipped — run interactively to remove certificate files)"
+        fi
+
+        if [ "$answer" = "y" ] || [ "$answer" = "Y" ]; then
+            rm -rf "$DATA_DIR"
+            info "Removed certificates directory: ${DATA_DIR}"
+        else
+            info "Kept certificates directory: ${DATA_DIR}"
         fi
     fi
 


### PR DESCRIPTION
## Summary
> **Stacked on #169** (`fix/third-party-notices`) — that PR already modifies release.yml and the README License section. Review/merge it first; this will retarget to `main` once it merges.

Release/install/docs hygiene from the v1.0 follow-up review (`docs/V1-REVIEW-FOLLOWUP.md`, items 13, 16 + the release lows):

- **ICU guidance removed**: the published binary has `InvariantGlobalization=true` and never loads ICU, but install.sh warned fresh-system users and the README told Ubuntu 24.04/Debian 13 users to install `libicu72` (Debian 12's package). Both removed; CONTRIBUTING.md untouched — developers running the test projects genuinely need ICU.
- **SHA256 checksums**: the release job now publishes a `SHA256SUMS` asset covering every archive, and install.sh/install.ps1 verify the downloaded archive against it — hard fail on mismatch, graceful warning when SHA256SUMS doesn't exist (older releases) or no hash tool is available.
- **No more .pdb in release archives**: publish runs with `-p:DebugType=none`.
- **Test gate on releases**: a new `test` job (full `dotnet test -c Release` on ubuntu) gates the build matrix — previously a tag on an untested commit published untested binaries.
- **Fork PRs no longer get a red X** from claude-code-review.yml (job-level fork guard; the secret isn't available to forks).
- **uninstall.sh** now prompts to remove `~/.local/share/opcilloscope` (PKI/cert stores), matching uninstall.ps1 and the README's manual instructions — it previously declared success while leaving certificate data behind.
- **Docs**: CLAUDE.md's CLI section gains the missing `--insecure` flag; README notes that macOS binaries are unsigned (Gatekeeper quarantine + `xattr -d com.apple.quarantine` / curl-installer workaround). `.gitignore` gains `publish/`.

## Test plan
- [x] All workflow YAMLs parse; `bash -n` clean on install.sh/uninstall.sh; checksum match/tamper paths simulated functionally
- [x] `dotnet build Opcilloscope.sln -c Release` — 0 warnings, 0 errors
- [ ] pwsh unavailable in the build environment — install.ps1 changes follow the file's existing patterns but want a Windows smoke test
- [ ] Next tagged release: verify SHA256SUMS asset, no .pdb in archives, test job gates the matrix

---
Part of the v1 follow-up punch list (`docs/V1-REVIEW-FOLLOWUP.md`, items 13, 16 + lows).

https://claude.ai/code/session_012Vopnd9vWkzELveHRgZhie

---
_Generated by [Claude Code](https://claude.ai/code/session_012Vopnd9vWkzELveHRgZhie)_