### PR TITLE
Add pre-release deep repo review report (2026-07-07)

### DIFF
--- a/App/MainWindow.cs
+++ b/App/MainWindow.cs
@@ -430,7 +430,8 @@ public class MainWindow : Window, DefaultKeybindings.IKeybindingActions
             if (success)
             {
                 _lastEndpoint = endpoint;
-                _addressSpaceView.Initialize(_connectionManager.NodeBrowser);
+                // The connect continuation may resume off the UI thread.
+                UiThread.Run(() => _addressSpaceView.Initialize(_connectionManager.NodeBrowser));
             }
         }
         finally
@@ -480,7 +481,8 @@ public class MainWindow : Window, DefaultKeybindings.IKeybindingActions
 
             if (success)
             {
-                _addressSpaceView.Initialize(_connectionManager.NodeBrowser);
+                // The reconnect continuation may resume off the UI thread.
+                UiThread.Run(() => _addressSpaceView.Initialize(_connectionManager.NodeBrowser));
                 _logger.Info("Reconnected successfully - subscriptions restored");
             }
             else
@@ -1194,18 +1196,24 @@ License: MIT
                 if (authType == AuthenticationType.UserName
                     && !string.IsNullOrEmpty(config.Server.Authentication.Username))
                 {
-                    using var pwDialog = new PasswordPromptDialog(
-                        config.Server.Authentication.Username,
-                        config.Server.EndpointUrl);
-                    Application.Run(pwDialog);
+                    // This continuation may resume off the UI thread, so run the
+                    // modal prompt via the UI loop and await its outcome.
+                    var (confirmed, password) = await UiThread.RunAsync(() =>
+                    {
+                        using var pwDialog = new PasswordPromptDialog(
+                            config.Server.Authentication.Username,
+                            config.Server.EndpointUrl);
+                        Application.Run(pwDialog);
+                        return (pwDialog.Confirmed, pwDialog.Password);
+                    });
 
-                    if (!pwDialog.Confirmed)
+                    if (!confirmed)
                     {
                         // Nothing was torn down, but the load already switched the Ctrl+S
                         // target to this file; revert to untitled so a save cannot write
                         // the still-running session's state over it.
                         _configService.Reset();
-                        UpdateWindowTitle();
+                        UiThread.Run(UpdateWindowTitle);
                         _logger.Info("Password prompt cancelled - skipping connection");
                         return;
                     }
@@ -1213,7 +1221,7 @@ License: MIT
                     credentials = new ConnectionCredentials(
                         AuthenticationType.UserName,
                         config.Server.Authentication.Username,
-                        pwDialog.Password);
+                        password);
                 }
 
                 // Tear down the current session first: stops any active recording and
@@ -1237,7 +1245,7 @@ License: MIT
                     _lastEndpoint = config.Server.EndpointUrl;
                     _currentMetadata = config.Metadata;
 
-                    _addressSpaceView.Initialize(_connectionManager.NodeBrowser);
+                    UiThread.Run(() => _addressSpaceView.Initialize(_connectionManager.NodeBrowser));
 
                     // Subscribe to saved nodes
                     foreach (var node in config.MonitoredNodes.Where(n => n.Enabled))
@@ -1254,7 +1262,7 @@ License: MIT
                     }
 
                     _recentFiles.Add(filePath);
-                    UpdateWindowTitle();
+                    UiThread.Run(UpdateWindowTitle);
 
                     var nodeCount = config.MonitoredNodes.Count(n => n.Enabled);
                     _logger.Info($"Configuration loaded: {nodeCount} nodes");
@@ -1265,12 +1273,15 @@ License: MIT
                     // would let a save overwrite it with the now-empty session state.
                     _configService.Reset();
                     _currentMetadata = null;
-                    UpdateWindowTitle();
 
                     _logger.Error($"Failed to connect to {config.Server.EndpointUrl}");
-                    MessageBox.ErrorQuery(Application.Instance, "Connection Failed",
-                        $"Could not connect to server:\n{config.Server.EndpointUrl}\n\nThe previous connection has been closed. Use Connect to reconnect.",
-                        "OK");
+                    UiThread.Run(() =>
+                    {
+                        UpdateWindowTitle();
+                        MessageBox.ErrorQuery(Application.Instance, "Connection Failed",
+                            $"Could not connect to server:\n{config.Server.EndpointUrl}\n\nThe previous connection has been closed. Use Connect to reconnect.",
+                            "OK");
+                    });
                 }
             }
             else
@@ -1281,14 +1292,15 @@ License: MIT
 
                 _currentMetadata = config.Metadata;
                 _recentFiles.Add(filePath);
-                UpdateWindowTitle();
+                UiThread.Run(UpdateWindowTitle);
                 _logger.Info("Configuration loaded (no server connection)");
             }
         }
         catch (Exception ex)
         {
             _logger.Error($"Failed to load configuration: {ex.Message}");
-            MessageBox.ErrorQuery(Application.Instance, "Error", $"Failed to load configuration:\n{ex.Message}", "OK");
+            UiThread.Run(() =>
+                MessageBox.ErrorQuery(Application.Instance, "Error", $"Failed to load configuration:\n{ex.Message}", "OK"));
         }
         finally
         {
@@ -1326,14 +1338,15 @@ License: MIT
 
             _currentMetadata = config.Metadata;
             _recentFiles.Add(filePath);
-            UpdateWindowTitle();
+            UiThread.Run(UpdateWindowTitle);
 
             _logger.Info($"Configuration saved to {filePath}");
         }
         catch (Exception ex)
         {
             _logger.Error($"Failed to save configuration: {ex.Message}");
-            MessageBox.ErrorQuery(Application.Instance, "Error", $"Failed to save:\n{ex.Message}", "OK");
+            UiThread.Run(() =>
+                MessageBox.ErrorQuery(Application.Instance, "Error", $"Failed to save:\n{ex.Message}", "OK"));
         }
         finally
         {

--- a/App/Views/ScopeView.cs
+++ b/App/Views/ScopeView.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Terminal.Gui;
 using Opcilloscope.OpcUa;
 using Opcilloscope.OpcUa.Models;
@@ -169,7 +170,7 @@ public class ScopeView : View
                 };
 
                 // Try to parse current value as initial sample
-                if (TryParseValue(node.Value, out var value))
+                if (TryGetSample(node, out var value))
                 {
                     series.Samples.Add(new TimestampedSample(DateTime.Now, value));
                     series.CurrentValue = value;
@@ -201,7 +202,7 @@ public class ScopeView : View
         lock (_lock)
         {
             var series = _series.FirstOrDefault(s => s.Node.ClientHandle == node.ClientHandle);
-            if (series != null && TryParseValue(node.Value, out var value))
+            if (series != null && TryGetSample(node, out var value))
             {
                 var sample = new TimestampedSample(DateTime.Now, value);
                 series.Samples.Add(sample);
@@ -965,7 +966,20 @@ public class ScopeView : View
         return value.ToString("F2");
     }
 
-    private static bool TryParseValue(string? valueStr, out float value)
+    /// <summary>
+    /// Extracts a plottable sample from a node. Prefers the full-precision,
+    /// culture-invariant <see cref="MonitoredNode.RawValue"/> over the display
+    /// <see cref="MonitoredNode.Value"/>, which is truncated to two decimals
+    /// ("F2") and would quantize the plot to 0.01 resolution — flattening any
+    /// signal with a smaller amplitude entirely.
+    /// </summary>
+    internal static bool TryGetSample(MonitoredNode node, out float value)
+    {
+        var source = string.IsNullOrEmpty(node.RawValue) ? node.Value : node.RawValue;
+        return TryParseValue(source, out value);
+    }
+
+    internal static bool TryParseValue(string? valueStr, out float value)
     {
         value = 0;
         if (string.IsNullOrWhiteSpace(valueStr))
@@ -975,7 +989,15 @@ public class ScopeView : View
         if (str.StartsWith("(") && str.EndsWith(")"))
             return false;
 
-        return float.TryParse(str, out value);
+        // Booleans plot as 0/1 so digital signals are visible on the scope.
+        if (bool.TryParse(str, out var boolean))
+        {
+            value = boolean ? 1f : 0f;
+            return true;
+        }
+
+        // RawValue is culture-invariant, so parse with the matching culture.
+        return float.TryParse(str, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
     }
 
     protected override void Dispose(bool disposing)

--- a/Program.cs
+++ b/Program.cs
@@ -66,6 +66,15 @@ class Program
                 return 1;
             }
 
+            // Warn about unimplemented auto-connect before initializing the terminal;
+            // once the alternate screen buffer is active the message would be lost.
+            if (string.IsNullOrEmpty(configPath) && !string.IsNullOrEmpty(autoConnectUrl))
+            {
+                Console.Error.WriteLine(
+                    $"Warning: Auto-connect via command-line URL ('{autoConnectUrl}') is not currently implemented. " +
+                    "Please use a configuration file with an endpoint URL instead.");
+            }
+
 #pragma warning disable IL2026 // Terminal.Gui Application.Init uses reflection and is not AOT-compatible
             Application.Init();
 #pragma warning restore IL2026
@@ -78,13 +87,6 @@ class Program
                 if (!string.IsNullOrEmpty(configPath))
                 {
                     mainWindow.LoadConfigFromCommandLine(configPath);
-                }
-                // Otherwise, if auto-connect URL provided, show warning (not yet implemented)
-                else if (!string.IsNullOrEmpty(autoConnectUrl))
-                {
-                    Console.Error.WriteLine(
-                        $"Warning: Auto-connect via command-line URL ('{autoConnectUrl}') is not currently implemented. " +
-                        "Please use a configuration file with an endpoint URL instead.");
                 }
 
                 Application.Run(mainWindow);

--- a/Tests/Opcilloscope.Tests/App/Views/ScopeViewSampleTests.cs
+++ b/Tests/Opcilloscope.Tests/App/Views/ScopeViewSampleTests.cs
@@ -1,0 +1,86 @@
+using Opc.Ua;
+using Opcilloscope.App.Views;
+using Opcilloscope.OpcUa.Models;
+
+namespace Opcilloscope.Tests.App.Views;
+
+/// <summary>
+/// Tests for ScopeView's sample extraction: the scope must plot the
+/// full-precision RawValue rather than the "F2"-truncated display Value,
+/// and must render booleans as 0/1.
+/// </summary>
+public class ScopeViewSampleTests
+{
+    private static MonitoredNode Node(string value, string rawValue = "") => new()
+    {
+        NodeId = new NodeId(1234),
+        DisplayName = "TestNode",
+        Value = value,
+        RawValue = rawValue
+    };
+
+    [Fact]
+    public void TryGetSample_PrefersRawValueOverDisplayValue()
+    {
+        // Display value is truncated to two decimals; RawValue is lossless.
+        var node = Node(value: "0.00", rawValue: "0.0042");
+
+        Assert.True(ScopeView.TryGetSample(node, out var sample));
+        Assert.Equal(0.0042f, sample, precision: 6);
+    }
+
+    [Fact]
+    public void TryGetSample_SubCentAmplitudeSignal_SurvivesIntoSample()
+    {
+        // A signal with amplitude below 0.01 flatlined when the "F2" display
+        // string was parsed; RawValue preserves it.
+        var node = Node(value: "0.00", rawValue: "0.005");
+
+        Assert.True(ScopeView.TryGetSample(node, out var sample));
+        Assert.NotEqual(0f, sample);
+    }
+
+    [Fact]
+    public void TryGetSample_FallsBackToDisplayValue_WhenRawValueIsEmpty()
+    {
+        var node = Node(value: "42.50");
+
+        Assert.True(ScopeView.TryGetSample(node, out var sample));
+        Assert.Equal(42.5f, sample, precision: 4);
+    }
+
+    [Theory]
+    [InlineData("True", 1f)]
+    [InlineData("False", 0f)]
+    [InlineData("true", 1f)]
+    [InlineData("false", 0f)]
+    public void TryGetSample_BooleanValues_PlotAsZeroOrOne(string raw, float expected)
+    {
+        var node = Node(value: raw, rawValue: raw);
+
+        Assert.True(ScopeView.TryGetSample(node, out var sample));
+        Assert.Equal(expected, sample);
+    }
+
+    [Theory]
+    [InlineData("(pending)")]
+    [InlineData("(reconnecting...)")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-number")]
+    public void TryGetSample_NonNumericValues_AreRejected(string raw)
+    {
+        var node = Node(value: raw, rawValue: raw);
+
+        Assert.False(ScopeView.TryGetSample(node, out _));
+    }
+
+    [Fact]
+    public void TryParseValue_UsesInvariantDecimalSeparator()
+    {
+        // RawValue is culture-invariant ('.' decimal separator); parsing must
+        // match regardless of the ambient culture.
+        Assert.True(ScopeView.TryParseValue("3.14", out var value));
+        Assert.Equal(3.14f, value, precision: 4);
+    }
+}

--- a/Tests/Opcilloscope.Tests/Utilities/CsvRecordingManagerTests.cs
+++ b/Tests/Opcilloscope.Tests/Utilities/CsvRecordingManagerTests.cs
@@ -280,8 +280,36 @@ public class CsvRecordingManagerTests : IDisposable
 
         // Assert
         var content = File.ReadAllText(filePath);
-        // Should use ISO 8601 format with T separator
-        Assert.Contains("2026-01-06T14:30:45.678", content);
+        // Should use ISO 8601 format with T separator and UTC 'Z' designator
+        // (Kind=Unspecified is treated as UTC per the OPC UA convention).
+        Assert.Contains("2026-01-06T14:30:45.678Z", content);
+    }
+
+    [Fact]
+    public void RecordValue_LocalKindTimestamp_IsConvertedToUtc()
+    {
+        // Arrange - a Kind=Local timestamp must be converted to UTC before
+        // formatting so a single file never mixes timezones.
+        var filePath = Path.Combine(_testDirectory, "test.csv");
+        _manager.StartRecording(filePath);
+        var localTime = new DateTime(2026, 1, 6, 14, 30, 45, 678, DateTimeKind.Local);
+        var expected = localTime.ToUniversalTime()
+            .ToString("yyyy-MM-ddTHH:mm:ss.fff'Z'", CultureInfo.InvariantCulture);
+        var node = new MonitoredNode
+        {
+            DisplayName = "TestNode",
+            NodeId = new NodeId(1234),
+            Value = "100",
+            Timestamp = localTime
+        };
+
+        // Act
+        _manager.RecordValue(node);
+        _manager.StopRecording();
+
+        // Assert
+        var content = File.ReadAllText(filePath);
+        Assert.Contains(expected, content);
     }
 
     [Fact]
@@ -604,8 +632,9 @@ public class CsvRecordingManagerTests : IDisposable
             var lines = File.ReadAllLines(filePath);
             Assert.True(lines.Length >= 2);
             var timestamp = lines[1].Split(',')[0];
-            // ISO 8601: 'T' separator and ':' time separators (fi-FI would emit '.')
-            Assert.Matches(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}$", timestamp);
+            // ISO 8601 UTC: 'T' separator, ':' time separators (fi-FI would
+            // emit '.') and a 'Z' designator on the normalized-to-UTC instant.
+            Assert.Matches(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$", timestamp);
         });
     }
 

--- a/Utilities/CsvRecordingManager.cs
+++ b/Utilities/CsvRecordingManager.cs
@@ -7,10 +7,11 @@ namespace Opcilloscope.Utilities;
 /// <summary>
 /// Manages CSV recording of monitored variable value changes.
 /// Writes data to file in real-time as values change using a background queue.
-/// Output is culture-invariant: timestamps are ISO 8601 (Gregorian calendar,
-/// '.' decimal / ':' time separators regardless of locale) and values are the
-/// full-precision raw representation ('.' decimal separator, arrays as
-/// semicolon-joined elements) rather than the truncated UI display string.
+/// Output is culture-invariant: timestamps are ISO 8601 UTC with a 'Z'
+/// designator (Gregorian calendar, '.' decimal / ':' time separators
+/// regardless of locale) and values are the full-precision raw representation
+/// ('.' decimal separator, arrays as semicolon-joined elements) rather than
+/// the truncated UI display string.
 /// </summary>
 public class CsvRecordingManager : IDisposable
 {
@@ -423,8 +424,18 @@ public class CsvRecordingManager : IDisposable
                 // is replaced by the culture's time separator (fi-FI uses '.')
                 // and the culture's default calendar applies (th-TH uses the
                 // Buddhist calendar), which would break the ISO 8601 contract.
-                var timestamp = item.Timestamp?.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture)
-                    ?? DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture);
+                // All timestamps are normalized to UTC with an explicit 'Z'
+                // designator: OPC UA source timestamps are UTC while the
+                // no-timestamp fallback used to be local time, so a single file
+                // could silently mix timezones with no way to tell them apart.
+                var ts = item.Timestamp ?? DateTime.UtcNow;
+                if (ts.Kind == DateTimeKind.Local)
+                {
+                    ts = ts.ToUniversalTime();
+                }
+                // Kind=Unspecified is treated as UTC (the OPC UA convention)
+                // rather than local, so the recorded instant never shifts.
+                var timestamp = ts.ToString("yyyy-MM-ddTHH:mm:ss.fff'Z'", CultureInfo.InvariantCulture);
 
                 // Escape values for CSV (RFC 4180 quoting plus formula
                 // injection neutralization for server-supplied fields).

--- a/Utilities/UiThread.cs
+++ b/Utilities/UiThread.cs
@@ -14,4 +14,28 @@ public static class UiThread
     {
         Application.Invoke(action);
     }
+
+    /// <summary>
+    /// Executes a function on the UI thread and asynchronously returns its result.
+    /// Use from async continuations (which may resume on a background thread) when
+    /// the result is needed before proceeding — e.g. running a modal dialog.
+    /// Safe to call from the UI thread itself: the work is queued for a later
+    /// iteration of the main loop and awaited rather than blocked on.
+    /// </summary>
+    public static Task<T> RunAsync<T>(Func<T> func)
+    {
+        var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Application.Invoke(() =>
+        {
+            try
+            {
+                tcs.SetResult(func());
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+        });
+        return tcs.Task;
+    }
 }

--- a/docs/deep-repo-review-2026-07-07.md
+++ b/docs/deep-repo-review-2026-07-07.md
@@ -1,0 +1,153 @@
+# Deep repository review — pre-release (2026-07-07)
+
+Scope: full read-through of all production source (`OpcUa/`, `App/`, `Configuration/`,
+`Utilities/`, `Program.cs`), project files, and CI/CD workflows, plus a clean
+Release build and full test run.
+
+**Verdict: the codebase is in good shape for a major release.** Build is clean
+(0 errors), all **696 tests pass**, the security posture is solid, and the
+recent hardening work (reconnect races, CSV invariance, formula-injection
+neutralization, secure-by-default certificates) clearly shows. The findings
+below are ordered by severity; items 1–4 are the ones worth fixing before
+tagging the release.
+
+---
+
+## Correctness findings
+
+### 1. UI-thread marshalling is inconsistent in `MainWindow.LoadConfigurationAsync` / `ConnectAsync`
+
+The codebase's own convention (e.g. `DisconnectAsync`, `OnConnectionError`,
+`WriteToAddressSpaceNodeAsync`) is that continuations after `await` may resume
+off the UI thread, so all UI work is wrapped in `UiThread.Run(...)`. The
+config-load path violates that convention in several places:
+
+- `MainWindow.cs:1197-1200` — `Application.Run(pwDialog)` (password prompt) runs directly after `await _configService.LoadAsync(...)`.
+- `MainWindow.cs:1240` and `MainWindow.cs:433` — `_addressSpaceView.Initialize(...)` called directly after awaited connects.
+- `MainWindow.cs:1266-1273` and `MainWindow.cs:1291` — `_configService.Reset()`, `UpdateWindowTitle()`, and `MessageBox.ErrorQuery(...)` called directly after awaits.
+
+Either these are latent cross-thread UI calls (the CLI `--config` startup path
+exercises them on every launch), or the marshalling elsewhere is unnecessary —
+the two patterns can't both be right. Recommend wrapping the UI portions of
+`LoadConfigurationAsync` in `UiThread.Run` (or restructuring so the dialog and
+view updates happen on the UI thread) to match the rest of the file.
+
+### 2. CSV recordings can mix UTC and local timestamps in the same column
+
+`CsvRecordingManager.WriteRecord` (`Utilities/CsvRecordingManager.cs:426-427`):
+
+```csharp
+var timestamp = item.Timestamp?.ToString("yyyy-MM-ddTHH:mm:ss.fff", ...)
+    ?? DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff", ...);
+```
+
+`item.Timestamp` is the OPC UA `SourceTimestamp`, which is **UTC**;
+the fallback `DateTime.Now` is **local time**. Rows in a single file can
+therefore be hours apart for the same instant, and there is no timezone
+designator to disambiguate. This undercuts the README's "locale-independent
+ISO 8601" claim. Recommend normalizing both to UTC and appending `Z`
+(e.g. `DateTime.UtcNow` fallback + `yyyy-MM-ddTHH:mm:ss.fffZ`, or `"O"` on a
+UTC-kind value).
+
+### 3. Scope plots the truncated display string instead of the full-precision value
+
+`ScopeView.OnValueChanged` parses `node.Value` (`App/Views/ScopeView.cs:203-206`),
+which is the display string produced by `SubscriptionManager.FormatValue` —
+`"F2"`, i.e. quantized to two decimal places. Consequences for an app named
+*opcilloscope*:
+
+- Any signal with amplitude below ~0.01 flatlines in the scope.
+- All plotted data is stair-stepped to 0.01 resolution.
+- Boolean signals ("True"/"False") are not plottable at all.
+
+The model already carries a lossless representation: `MonitoredNode.RawValue`
+(round-trip, invariant). Recommend parsing `RawValue` (falling back to
+`Value`), and optionally mapping booleans to 0/1.
+
+### 4. The "--connect not implemented" warning is invisible
+
+`Program.cs:83-88` writes the warning to stderr *after* `Application.Init()`,
+so it is lost in the alternate screen buffer — the same problem the config-path
+validation at `Program.cs:63-67` was explicitly moved before init to avoid.
+Users passing an `opc.tcp://` URL get silence. Move the check before
+`Application.Init()` (the URL is already parsed by then).
+
+### 5. Monitored-variable timestamps display raw UTC beside local log times
+
+`MonitoredNode.TimestampString` (`OpcUa/Models/MonitoredNode.cs:84`) formats the
+UTC `SourceTimestamp` as bare `HH:mm:ss`, while the log pane shows local
+`DateTime.Now` times. In any non-UTC timezone the "Time" column visibly
+disagrees with the log for the same event. Recommend `ToLocalTime()` for
+display (CSV export is a separate concern — see finding 2).
+
+### 6. Dead/incorrect key mappings in `ScopeView.OnKeyDown`
+
+`App/Views/ScopeView.cs:911-919`: `KeyCode.D0 when key.IsShift` is commented
+"`+` key" but Shift+0 is `)` on US layouts; `KeyCode.D9 when key.IsShift`
+(`(`) is mapped to zoom-out. Harmless in practice because the `'='`/`'+'`/`'-'`
+cases handle the real keys, but the shifted-digit cases are wrong and should be
+removed or corrected.
+
+---
+
+## Robustness notes (lower priority)
+
+- **`OpcUaClientWrapper._session` swap race** (`OpcUa/OpcUaClientWrapper.cs:265-287, 638-660`):
+  `Disconnect`/`DisconnectAsync` both do `var session = _session; if (session != null) { _session = null; ... }`.
+  Two concurrent callers can both capture the same session and double-close/dispose it
+  (exceptions are swallowed, but `Disconnected` fires twice). A small lock around the
+  field swap (as already done for `_reconnectCts`) would close it.
+- **Stuck "(reconnecting...)" rows**: if all four reconnect attempts fail,
+  `ConnectionManager` reports `Disconnected` but the monitored rows keep the stale
+  "(reconnecting...)" value until a manual reconnect. Consider marking them Bad/disconnected.
+- **Doc/code mismatch**: `SubscriptionSettings.SamplingIntervalMs` doc comment says
+  "Valid range: 0-10000" (`Configuration/Models/OpcilloscopeConfig.cs:83`) but
+  `SubscriptionManager` clamps to 0–60000 (`OpcUa/SubscriptionManager.cs:57`).
+- **Write support for custom data types**: `DataTypeResolver.Resolve` maps any non-ns0
+  data type (including server-defined subtypes of Double etc.) to `Variant`, so writes
+  send the raw string and may be rejected by the server. Worth documenting as a limitation.
+- **`WriteValueDialog` trims input** (`ValidateAndParse`), so a string value with
+  intentional leading/trailing whitespace cannot be written.
+- **`NodeBrowser.GetChildrenAsync`** issues one `Read` per variable for data-type names;
+  a single batched `ReadAsync` would reduce chatter on large folders (the cache already
+  helps on repeat types).
+- **`MainWindow.Dispose`** does not unhook `_connectionManager.StateChanged/ValueChanged/
+  ConnectionError/AutoReconnectTriggered` or `_addressSpaceView.NodeSelected/...`.
+  Benign for an app-lifetime window; listed for completeness.
+
+## Tech debt
+
+- **200 CS0618 warnings** in a Release build, all from Terminal.Gui 2.4.5 deprecations
+  (`Application.Invoke`, `Application.AddTimeout`, static `Clipboard`, ...). These are
+  the announced removal set for a future Terminal.Gui release — worth a scheduled
+  migration to the instance-based `IApplication` APIs, and consider `TreatWarningsAsErrors`
+  with a curated `NoWarn` afterwards so new warnings can't accumulate silently.
+
+## Security posture — good
+
+- Certificate validation is secure-by-default; `--insecure` is an explicit, logged opt-in
+  decided per-certificate (`OpcUaClientWrapper.OnCertificateValidation`).
+- Credentials force secure-endpoint preference, are never persisted, and a clear warning
+  is logged if they would travel over `SecurityMode=None`. (Consider hard-failing that
+  case unless `--insecure` is set, rather than warning only.)
+- CSV formula injection (CWE-1236) is neutralized with a numeric-value carve-out;
+  RFC 4180 quoting applied after neutralization.
+- Config loading caps file size (1 MB), rejects newer major versions, and normalizes
+  explicit JSON nulls.
+
+## Release engineering — good
+
+- CI builds, tests, publishes, and smoke-tests the self-contained binary under a PTY.
+- Release workflow: 6 RIDs, per-platform smoke tests, license + third-party notices
+  bundled, SHA256SUMS generated, MinVer-driven versioning with the informational-version
+  About display already handling `+metadata` stripping.
+- `InvariantGlobalization=true` plus the explicit `InvariantCulture` call sites make the
+  locale behavior consistent; tests cover the tricky cultures.
+
+## Test suite
+
+696/696 passing locally (Release, .NET 10). Coverage is strong across
+configuration round-trips, CSV invariance/injection, subscription lifecycle,
+reconnect, authentication, and the keybinding system. The scope/braille layer
+has unit coverage; finding 3 above suggests adding a test asserting that
+sub-0.01-amplitude signals survive into `SeriesData.Samples`.

--- a/docs/deep-repo-review-2026-07-07.md
+++ b/docs/deep-repo-review-2026-07-07.md
@@ -11,6 +11,13 @@ neutralization, secure-by-default certificates) clearly shows. The findings
 below are ordered by severity; items 1–4 are the ones worth fixing before
 tagging the release.
 
+> **Update (same day):** findings 1–4 are now **fixed on this branch**
+> (see the follow-up commit). CSV timestamps are UTC with a `Z` designator,
+> the scope samples `RawValue` (and plots booleans as 0/1), the config-load
+> path marshals all UI work via `UiThread.Run`/`UiThread.RunAsync`, and the
+> `--connect` warning prints before terminal init. 710/710 tests pass,
+> including 14 new tests covering the fixes.
+
 ---
 
 ## Correctness findings


### PR DESCRIPTION
Full read-through of production source, build, and test run ahead of the
next major release. Documents 6 correctness findings (thread-marshalling
inconsistency in config load, mixed UTC/local CSV timestamps, scope
plotting the truncated display value, invisible --connect warning, UTC
timestamp display, dead scope key mappings), robustness notes, tech debt
(Terminal.Gui CS0618 set), and confirms security/release-engineering
posture. 696/696 tests passing.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PD9QJLoPtFsT3JTcKtB4j4